### PR TITLE
Ensure contracts schema validation loads date-time formats

### DIFF
--- a/.github/workflows/contracts.yml
+++ b/.github/workflows/contracts.yml
@@ -8,10 +8,10 @@ jobs:
       - uses: actions/checkout@v4
       - name: Validate JSON schemas
         run: |
-          npm i -g ajv-cli@5
-          ajv validate -s contracts/semantics/node.schema.json -d '{}' || true
-          ajv validate -s contracts/semantics/edge.schema.json -d '{}' || true
-          ajv validate -s contracts/semantics/report.schema.json -d '{}' || true
+          npm i -g ajv-cli@5 ajv-formats
+          ajv validate --extend=ajv-formats -s contracts/semantics/node.schema.json -d '{}' || true
+          ajv validate --extend=ajv-formats -s contracts/semantics/edge.schema.json -d '{}' || true
+          ajv validate --extend=ajv-formats -s contracts/semantics/report.schema.json -d '{}' || true
   docs-style:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## Summary
- install ajv-formats alongside ajv-cli in the contracts schema validation workflow
- extend the ajv CLI invocation with ajv-formats so date-time fields are validated correctly

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68de76651984832caa638ed9a0862b8a