### PR TITLE
Fix markdown lint warnings in runbooks

### DIFF
--- a/docs/runbook.observability.md
+++ b/docs/runbook.observability.md
@@ -1,0 +1,13 @@
+# Observability Runbook
+
+## Overview
+
+This runbook describes how to access the local observability stack while developing semantAH. The stack is composed of Grafana, Loki, and Tempo containers that expose HTTP interfaces for debugging and tracing.
+
+## Endpoints
+
+- Grafana: [http://localhost:3000](http://localhost:3000)
+- Loki: [http://localhost:3100](http://localhost:3100)
+- Tempo: [http://localhost:3200](http://localhost:3200)
+
+Use these endpoints to inspect logs, metrics, and traces when diagnosing issues in the development environment.

--- a/docs/runbooks/semantics-intake.md
+++ b/docs/runbooks/semantics-intake.md
@@ -1,0 +1,7 @@
+<!-- Runbook for manually intaking semantics data -->
+
+# Semantics Intake (manuell)
+
+1) Von semantAH: `.gewebe/out/...`
+2) Archivieren und aufbereiten gemäß Prozessbeschreibung.
+3) Übertragen in das Zielsystem laut Betriebshandbuch.


### PR DESCRIPTION
## Summary
- add the observability runbook and convert local service URLs into Markdown links
- ensure the semantics intake runbook has the required blank lines around headings and lists

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68de765d1a5c832caa84acd2978b3c72