### PR TITLE
Align semantics contracts with blueprint

### DIFF
--- a/contracts/semantics/edge.schema.json
+++ b/contracts/semantics/edge.schema.json
@@ -3,12 +3,16 @@
   "title": "SemEdge",
   "type": "object",
   "required": ["src", "dst", "rel"],
+  "additionalProperties": false,
   "properties": {
     "src": { "type": "string" },
     "dst": { "type": "string" },
     "rel": { "type": "string" },
     "weight": { "type": "number" },
-    "why": { "type": "string" },
+    "why": {
+      "type": "array",
+      "items": { "type": "string" }
+    },
     "updated_at": { "type": "string", "format": "date-time" }
   }
 }

--- a/contracts/semantics/node.schema.json
+++ b/contracts/semantics/node.schema.json
@@ -2,33 +2,22 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "SemNode",
   "type": "object",
-  "required": [
-    "id",
-    "type",
-    "title"
-  ],
+  "required": ["id", "type", "title"],
+  "additionalProperties": false,
   "properties": {
-    "id": {
-      "type": "string"
-    },
-    "type": {
-      "type": "string"
-    },
-    "title": {
-      "type": "string"
-    },
+    "id": { "type": "string" },
+    "type": { "type": "string" },
+    "title": { "type": "string" },
     "tags": {
       "type": "array",
-      "items": {
-        "type": "string"
-      }
+      "items": { "type": "string" }
     },
-    "source": {
-      "type": "string"
+    "topics": {
+      "type": "array",
+      "items": { "type": "string" }
     },
-    "updated_at": {
-      "type": "string",
-      "format": "date-time"
-    }
+    "cluster": { "type": "integer" },
+    "source": { "type": "string" },
+    "updated_at": { "type": "string", "format": "date-time" }
   }
 }

--- a/docs/blueprint.md
+++ b/docs/blueprint.md
@@ -83,8 +83,8 @@ persons:
 **Edges (`edges.jsonl`)**
 
 ```json
-{"s":"md:gfk.md","p":"about","o":"topic:Gewaltfreie Kommunikation","w":0.92,"why":["shared:keyphrase:GFK","same:cluster"]}
-{"s":"md:verena.md","p":"similar","o":"md:tatjana.md","w":0.81,"why":["cluster:7","quote:'…'"]}
+{"src":"md:gfk.md","rel":"about","dst":"topic:Gewaltfreie Kommunikation","weight":0.92,"why":["shared:keyphrase:GFK","same:cluster"]}
+{"src":"md:verena.md","rel":"similar","dst":"md:tatjana.md","weight":0.81,"why":["cluster:7","quote:'…'"]}
 ```
 
 Das Feld `why` speichert die Top-Rationales (Keyphrases, Cluster, Anker-Sätze) und ermöglicht Explainability.


### PR DESCRIPTION
## Summary
- make the semantics node and edge schemas stricter and align them with the documented fields
- update the blueprint examples to reflect the schema field names and array-based rationales

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68de75f040ec832cbbf6c31c2a8e62c3