### PR TITLE
Fix indexd server startup for axum 0.7

### DIFF
--- a/crates/indexd/src/main.rs
+++ b/crates/indexd/src/main.rs
@@ -4,7 +4,7 @@ use std::net::SocketAddr;
 
 use axum::{routing::post, Json, Router};
 use serde::{Deserialize, Serialize};
-use tokio::signal;
+use tokio::{net::TcpListener, signal};
 use tracing::{info, Level};
 use tracing_subscriber::FmtSubscriber;
 
@@ -69,8 +69,9 @@ async fn main() -> anyhow::Result<()> {
     let addr: SocketAddr = "0.0.0.0:8081".parse()?;
     info!(%addr, "starting indexd stub");
 
-    axum::Server::bind(&addr)
-        .serve(router.into_make_service())
+    let listener = TcpListener::bind(addr).await?;
+
+    axum::serve(listener, router)
         .with_graceful_shutdown(shutdown_signal())
         .await?;
 


### PR DESCRIPTION
## Summary
- replace the deprecated `axum::Server::bind` usage with `axum::serve`
- use Tokio's `TcpListener` to bind the indexd stub endpoint before serving

## Testing
- cargo test

------
https://chatgpt.com/codex/tasks/task_e_68dfa6fa6a88832caf93d27037d84951