### PR TITLE
Update org references to heimgewebe

### DIFF
--- a/.wgx/profile.yml
+++ b/.wgx/profile.yml
@@ -77,7 +77,7 @@ tasks:
         [ -f pyproject.toml ] && grep -q '\[project\]' pyproject.toml || true
 
 meta:
-  owner: "alexdermohr"
+  owner: "heimgewebe"
   conventions:
     gewebedir: ".gewebe"
     version_endpoint: "/version"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # semantAH
 
-**semantAH** ist der semantische Index- und Graph-Ableger von [HausKI](https://github.com/alexdermohr/hauski).
+**semantAH** ist der semantische Index- und Graph-Ableger von [HausKI](https://github.com/heimgewebe/hausKI).
 Es zerlegt Notizen (z. B. aus Obsidian), erstellt **Embeddings**, baut daraus einen **Index und Wissensgraphen** und schreibt „Related“-Blöcke direkt in die Markdown-Dateien zurück.
 
 - **Einbettung in HausKI:** dient dort als semantische Gedächtnis-Schicht (Memory Layer).


### PR DESCRIPTION
## Summary
- update the README link to point to the HausKI repository under the heimgewebe organization
- align the wgx profile metadata owner with the heimgewebe organization

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e4b8675660832c924f7a232a90020b