### PR TITLE
Update documentation for heimgewebe organization

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 # uv / Python
 .venv/
 .uv/
+*.egg-info/

--- a/.wgx/profile.yml
+++ b/.wgx/profile.yml
@@ -77,7 +77,7 @@ tasks:
         [ -f pyproject.toml ] && grep -q '\[project\]' pyproject.toml || true
 
 meta:
-  owner: "alexdermohr"
+  owner: "heimgewebe"
   conventions:
     gewebedir: ".gewebe"
     version_endpoint: "/version"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # semantAH
 
-**semantAH** ist der semantische Index- und Graph-Ableger von [HausKI](https://github.com/alexdermohr/hauski).
+**semantAH** ist der semantische Index- und Graph-Ableger von [HausKI](https://github.com/heimgewebe/hausKI).
 Es zerlegt Notizen (z. B. aus Obsidian), erstellt **Embeddings**, baut daraus einen **Index und Wissensgraphen** und schreibt „Related“-Blöcke direkt in die Markdown-Dateien zurück.
 
 - **Einbettung in HausKI:** dient dort als semantische Gedächtnis-Schicht (Memory Layer).
@@ -76,8 +76,8 @@ Aktuell implementiert/geplant (beweglich):
 
 ## Veröffentlichungs-Workflow
 
-1. Erstelle ein neues GitHub-Repo: `gh repo create alex/semantAH --public`.
-2. Verbinde dein lokales Repo: `git init`, `git remote add origin git@github.com:alex/semantAH.git`.
+1. Erstelle ein neues GitHub-Repo: `gh repo create heimgewebe/semantAH --public`.
+2. Verbinde dein lokales Repo: `git init`, `git remote add origin git@github.com:heimgewebe/semantAH.git`.
 3. Commit & push: `git add . && git commit -m "Initial commit" && git push -u origin main`.
 
 ## Lizenz


### PR DESCRIPTION
## Summary
- update the publication workflow instructions to point at the heimgewebe/semantAH repository
- ignore generated Python egg-info metadata directories in git

## Testing
- not run (documentation-only changes)

------
https://chatgpt.com/codex/tasks/task_e_68e4cb8263b8832cbc38d8400ea73ac1