### PR TITLE
Implement in-memory vector store for indexd

### DIFF
--- a/crates/indexd/src/lib.rs
+++ b/crates/indexd/src/lib.rs
@@ -1,0 +1,24 @@
+pub mod store;
+
+use tokio::sync::RwLock;
+
+#[derive(Debug)]
+pub struct AppState {
+    pub store: RwLock<store::VectorStore>,
+}
+
+impl AppState {
+    pub fn new() -> Self {
+        Self {
+            store: RwLock::new(store::VectorStore::new()),
+        }
+    }
+}
+
+impl Default for AppState {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+pub use store::{VectorStore, VectorStoreError};

--- a/crates/indexd/src/main.rs
+++ b/crates/indexd/src/main.rs
@@ -1,12 +1,15 @@
 //! Minimal HTTP server stub for the semantic index daemon (indexd).
 
-use std::net::SocketAddr;
+use std::{net::SocketAddr, sync::Arc};
 
-use axum::{routing::post, Json, Router};
+use axum::{extract::State, http::StatusCode, routing::post, Json, Router};
 use serde::{Deserialize, Serialize};
+use serde_json::{json, Value};
 use tokio::{net::TcpListener, signal};
 use tracing::{info, Level};
 use tracing_subscriber::FmtSubscriber;
+
+use indexd::AppState;
 
 #[derive(Debug, Deserialize)]
 struct UpsertRequest {
@@ -18,9 +21,10 @@ struct UpsertRequest {
 #[derive(Debug, Deserialize)]
 struct ChunkPayload {
     id: String,
-    text: String,
+    #[serde(rename = "text")]
+    _text: String,
     #[serde(default)]
-    meta: serde_json::Value,
+    meta: Value,
 }
 
 #[derive(Debug, Deserialize)]
@@ -34,9 +38,10 @@ struct SearchRequest {
     query: String,
     #[serde(default = "default_k")]
     k: u32,
-    namespace: String,
-    #[serde(default)]
-    filters: serde_json::Value,
+    #[serde(rename = "namespace")]
+    _namespace: String,
+    #[serde(default, rename = "filters")]
+    _filters: Value,
 }
 
 #[derive(Debug, Serialize)]
@@ -61,10 +66,13 @@ fn default_k() -> u32 {
 async fn main() -> anyhow::Result<()> {
     init_tracing();
 
+    let state = Arc::new(AppState::new());
+
     let router = Router::new()
         .route("/index/upsert", post(handle_upsert))
         .route("/index/delete", post(handle_delete))
-        .route("/index/search", post(handle_search));
+        .route("/index/search", post(handle_search))
+        .with_state(state);
 
     let addr: SocketAddr = "0.0.0.0:8081".parse()?;
     info!(%addr, "starting indexd stub");
@@ -111,20 +119,79 @@ async fn shutdown_signal() {
     }
 }
 
-async fn handle_upsert(Json(payload): Json<UpsertRequest>) -> Json<serde_json::Value> {
-    // TODO: wire up embeddings + HNSW persistence.
-    info!(doc_id = %payload.doc_id, chunks = payload.chunks.len(), "received upsert");
-    Json(serde_json::json!({
+async fn handle_upsert(
+    State(state): State<Arc<AppState>>,
+    Json(payload): Json<UpsertRequest>,
+) -> Result<Json<Value>, (StatusCode, Json<Value>)> {
+    let chunk_count = payload.chunks.len();
+    info!(doc_id = %payload.doc_id, chunks = chunk_count, "received upsert");
+
+    let UpsertRequest {
+        doc_id,
+        namespace,
+        chunks,
+    } = payload;
+
+    let mut store = state.store.write().await;
+
+    for chunk in chunks {
+        let ChunkPayload { id, _text: _, meta } = chunk;
+
+        let mut meta = match meta {
+            Value::Object(map) => map,
+            _ => return Err(bad_request("chunk meta must be an object")),
+        };
+
+        let embedding_value = meta
+            .remove("embedding")
+            .ok_or_else(|| bad_request("chunk meta must contain an embedding array"))?;
+
+        let vector = parse_embedding(embedding_value).map_err(|err| bad_request(err))?;
+
+        store
+            .upsert(&namespace, &doc_id, &id, vector, Value::Object(meta))
+            .map_err(|err| bad_request(err.to_string()))?;
+    }
+
+    Ok(Json(json!({
         "status": "accepted",
-        "chunks": payload.chunks.len(),
+        "chunks": chunk_count,
+    })))
+}
+
+async fn handle_delete(
+    State(state): State<Arc<AppState>>,
+    Json(payload): Json<DeleteRequest>,
+) -> Json<Value> {
+    info!(doc_id = %payload.doc_id, "received delete");
+
+    let mut store = state.store.write().await;
+    store.delete_doc(&payload.namespace, &payload.doc_id);
+
+    Json(json!({
+        "status": "accepted"
     }))
 }
 
-async fn handle_delete(Json(payload): Json<DeleteRequest>) -> Json<serde_json::Value> {
-    info!(doc_id = %payload.doc_id, "received delete");
-    Json(serde_json::json!({
-        "status": "accepted"
-    }))
+fn parse_embedding(value: Value) -> Result<Vec<f32>, String> {
+    match value {
+        Value::Array(values) => values
+            .into_iter()
+            .map(|v| {
+                v.as_f64()
+                    .map(|num| num as f32)
+                    .ok_or_else(|| "embedding must be an array of numbers".to_string())
+            })
+            .collect(),
+        _ => Err("embedding must be an array of numbers".to_string()),
+    }
+}
+
+fn bad_request(message: impl Into<String>) -> (StatusCode, Json<Value>) {
+    let body = json!({
+        "error": message.into(),
+    });
+    (StatusCode::BAD_REQUEST, Json(body))
 }
 
 async fn handle_search(Json(payload): Json<SearchRequest>) -> Json<SearchResponse> {

--- a/crates/indexd/src/store.rs
+++ b/crates/indexd/src/store.rs
@@ -1,0 +1,93 @@
+use std::collections::HashMap;
+
+use serde_json::Value;
+use thiserror::Error;
+
+const KEY_SEPARATOR: &str = "\u{241F}";
+
+#[derive(Debug, Default)]
+pub struct VectorStore {
+    pub dims: Option<usize>,
+    pub items: HashMap<(String, String), (Vec<f32>, Value)>,
+}
+
+impl VectorStore {
+    pub fn new() -> Self {
+        Self {
+            dims: None,
+            items: HashMap::new(),
+        }
+    }
+
+    pub fn upsert(
+        &mut self,
+        namespace: &str,
+        doc_id: &str,
+        chunk_id: &str,
+        vector: Vec<f32>,
+        meta: Value,
+    ) -> Result<(), VectorStoreError> {
+        if let Some(expected) = self.dims {
+            if expected != vector.len() {
+                return Err(VectorStoreError::DimensionalityMismatch {
+                    expected,
+                    actual: vector.len(),
+                });
+            }
+        } else {
+            self.dims = Some(vector.len());
+        }
+
+        let key = (namespace.to_string(), make_chunk_key(doc_id, chunk_id));
+        self.items.insert(key, (vector, meta));
+        Ok(())
+    }
+
+    pub fn delete_doc(&mut self, namespace: &str, doc_id: &str) {
+        let prefix = format!("{doc_id}{KEY_SEPARATOR}");
+        self.items
+            .retain(|(ns, key), _| !(ns == namespace && key.starts_with(&prefix)));
+    }
+
+    pub fn all_in_namespace<'a>(
+        &'a self,
+        namespace: &'a str,
+    ) -> impl Iterator<Item = (&'a (String, String), &'a (Vec<f32>, Value))> + 'a {
+        self.items
+            .iter()
+            .filter(move |((ns, _), _)| ns == namespace)
+    }
+}
+
+#[derive(Debug, Error)]
+pub enum VectorStoreError {
+    #[error("embedding dimensionality mismatch: expected {expected}, got {actual}")]
+    DimensionalityMismatch { expected: usize, actual: usize },
+}
+
+fn make_chunk_key(doc_id: &str, chunk_id: &str) -> String {
+    format!("{doc_id}{KEY_SEPARATOR}{chunk_id}")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn upsert_delete_smoke() {
+        let mut store = VectorStore::new();
+        let meta = Value::Null;
+        store
+            .upsert("namespace", "doc", "chunk-1", vec![0.1, 0.2], meta.clone())
+            .expect("first insert sets dims");
+        store
+            .upsert("namespace", "doc", "chunk-2", vec![0.3, 0.4], meta)
+            .expect("second insert matches dims");
+
+        assert_eq!(store.items.len(), 2);
+
+        store.delete_doc("namespace", "doc");
+
+        assert!(store.items.is_empty(), "store should be empty after delete");
+    }
+}


### PR DESCRIPTION
## Summary
- add an in-memory `VectorStore` with dimensionality validation and deletion helpers
- expose `AppState` backed by the store and wire axum handlers to persist chunk embeddings
- validate upsert payload embeddings and remove stored chunks on delete

## Testing
- cargo test -p indexd

------
https://chatgpt.com/codex/tasks/task_e_68e512a02f30832c86a26e614a5bf811