### PR TITLE
Fix indexd health test for router state

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -792,6 +792,7 @@ dependencies = [
  "serde_json",
  "thiserror",
  "tokio",
+ "tower",
  "tracing",
  "tracing-subscriber",
 ]

--- a/crates/indexd/Cargo.toml
+++ b/crates/indexd/Cargo.toml
@@ -20,3 +20,6 @@ futures.workspace = true
 [dependencies.embeddings]
 path = "../embeddings"
 
+[dev-dependencies]
+tower = "0.5"
+

--- a/crates/indexd/src/lib.rs
+++ b/crates/indexd/src/lib.rs
@@ -1,0 +1,95 @@
+pub mod store;
+
+use std::{net::SocketAddr, sync::Arc};
+
+use axum::{routing::get, Router};
+use tokio::sync::RwLock;
+use tokio::{net::TcpListener, signal};
+use tracing::{info, Level};
+use tracing_subscriber::FmtSubscriber;
+
+#[derive(Debug)]
+pub struct AppState {
+    pub store: RwLock<store::VectorStore>,
+}
+
+impl AppState {
+    pub fn new() -> Self {
+        Self {
+            store: RwLock::new(store::VectorStore::new()),
+        }
+    }
+}
+
+impl Default for AppState {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+pub use store::{VectorStore, VectorStoreError};
+
+#[derive(Clone, Default)]
+pub struct App;
+
+pub fn router(state: Arc<AppState>) -> Router {
+    Router::new()
+        .route("/healthz", get(healthz))
+        .with_state(state)
+}
+
+pub async fn run(
+    build_routes: impl FnOnce(Arc<AppState>) -> Router + Send + 'static,
+) -> anyhow::Result<()> {
+    init_tracing();
+
+    let state = Arc::new(AppState::new());
+    let router = build_routes(state.clone()).merge(router(state));
+
+    let addr: SocketAddr = "0.0.0.0:8080".parse()?;
+    info!(%addr, "starting indexd");
+
+    let listener = TcpListener::bind(addr).await?;
+    axum::serve(listener, router)
+        .with_graceful_shutdown(shutdown_signal())
+        .await?;
+
+    info!("indexd stopped");
+    Ok(())
+}
+
+fn init_tracing() {
+    let subscriber = FmtSubscriber::builder()
+        .with_max_level(Level::INFO)
+        .with_target(false)
+        .finish();
+    let _ = tracing::subscriber::set_global_default(subscriber);
+}
+
+async fn shutdown_signal() {
+    let ctrl_c = async {
+        signal::ctrl_c()
+            .await
+            .expect("failed to install CTRL+C handler");
+    };
+
+    #[cfg(unix)]
+    let terminate = async {
+        signal::unix::signal(signal::unix::SignalKind::terminate())
+            .expect("failed to install signal handler")
+            .recv()
+            .await;
+    };
+
+    #[cfg(not(unix))]
+    let terminate = std::future::pending::<()>();
+
+    tokio::select! {
+        _ = ctrl_c => {},
+        _ = terminate => {},
+    }
+}
+
+async fn healthz() -> &'static str {
+    "ok"
+}

--- a/crates/indexd/src/main.rs
+++ b/crates/indexd/src/main.rs
@@ -1,12 +1,12 @@
 //! Minimal HTTP server stub for the semantic index daemon (indexd).
 
-use std::net::SocketAddr;
+use std::sync::Arc;
 
-use axum::{routing::post, Json, Router};
+use axum::{extract::State, http::StatusCode, routing::post, Json, Router};
+use indexd::AppState;
 use serde::{Deserialize, Serialize};
-use tokio::{net::TcpListener, signal};
-use tracing::{info, Level};
-use tracing_subscriber::FmtSubscriber;
+use serde_json::{json, Value};
+use tracing::info;
 
 #[derive(Debug, Deserialize)]
 struct UpsertRequest {
@@ -18,9 +18,10 @@ struct UpsertRequest {
 #[derive(Debug, Deserialize)]
 struct ChunkPayload {
     id: String,
-    text: String,
+    #[serde(rename = "text")]
+    _text: String,
     #[serde(default)]
-    meta: serde_json::Value,
+    meta: Value,
 }
 
 #[derive(Debug, Deserialize)]
@@ -34,9 +35,10 @@ struct SearchRequest {
     query: String,
     #[serde(default = "default_k")]
     k: u32,
-    namespace: String,
-    #[serde(default)]
-    filters: serde_json::Value,
+    #[serde(rename = "namespace")]
+    _namespace: String,
+    #[serde(default, rename = "filters")]
+    _filters: Value,
 }
 
 #[derive(Debug, Serialize)]
@@ -59,72 +61,89 @@ fn default_k() -> u32 {
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
-    init_tracing();
-
-    let router = Router::new()
-        .route("/index/upsert", post(handle_upsert))
-        .route("/index/delete", post(handle_delete))
-        .route("/index/search", post(handle_search));
-
-    let addr: SocketAddr = "0.0.0.0:8081".parse()?;
-    info!(%addr, "starting indexd stub");
-
-    let listener = TcpListener::bind(addr).await?;
-
-    axum::serve(listener, router)
-        .with_graceful_shutdown(shutdown_signal())
-        .await?;
-
-    info!("indexd stopped");
-    Ok(())
+    indexd::run(|state| {
+        Router::new()
+            .route("/index/upsert", post(handle_upsert))
+            .route("/index/delete", post(handle_delete))
+            .route("/index/search", post(handle_search))
+            .with_state(state)
+    })
+    .await
 }
 
-fn init_tracing() {
-    let subscriber = FmtSubscriber::builder()
-        .with_max_level(Level::INFO)
-        .with_target(false)
-        .finish();
-    let _ = tracing::subscriber::set_global_default(subscriber);
+async fn handle_upsert(
+    State(state): State<Arc<AppState>>,
+    Json(payload): Json<UpsertRequest>,
+) -> Result<Json<Value>, (StatusCode, Json<Value>)> {
+    let chunk_count = payload.chunks.len();
+    info!(doc_id = %payload.doc_id, chunks = chunk_count, "received upsert");
+
+    let UpsertRequest {
+        doc_id,
+        namespace,
+        chunks,
+    } = payload;
+
+    let mut store = state.store.write().await;
+
+    for chunk in chunks {
+        let ChunkPayload { id, _text: _, meta } = chunk;
+
+        let mut meta = match meta {
+            Value::Object(map) => map,
+            _ => return Err(bad_request("chunk meta must be an object")),
+        };
+
+        let embedding_value = meta
+            .remove("embedding")
+            .ok_or_else(|| bad_request("chunk meta must contain an embedding array"))?;
+
+        let vector = parse_embedding(embedding_value).map_err(bad_request)?;
+
+        store
+            .upsert(&namespace, &doc_id, &id, vector, Value::Object(meta))
+            .map_err(|err| bad_request(err.to_string()))?;
+    }
+
+    Ok(Json(json!({
+        "status": "accepted",
+        "chunks": chunk_count,
+    })))
 }
 
-async fn shutdown_signal() {
-    let ctrl_c = async {
-        signal::ctrl_c()
-            .await
-            .expect("failed to install CTRL+C handler");
-    };
+async fn handle_delete(
+    State(state): State<Arc<AppState>>,
+    Json(payload): Json<DeleteRequest>,
+) -> Json<Value> {
+    info!(doc_id = %payload.doc_id, "received delete");
 
-    #[cfg(unix)]
-    let terminate = async {
-        signal::unix::signal(signal::unix::SignalKind::terminate())
-            .expect("failed to install signal handler")
-            .recv()
-            .await;
-    };
+    let mut store = state.store.write().await;
+    store.delete_doc(&payload.namespace, &payload.doc_id);
 
-    #[cfg(not(unix))]
-    let terminate = std::future::pending::<()>();
+    Json(json!({
+        "status": "accepted"
+    }))
+}
 
-    tokio::select! {
-        _ = ctrl_c => {},
-        _ = terminate => {},
+fn parse_embedding(value: Value) -> Result<Vec<f32>, String> {
+    match value {
+        Value::Array(values) => values
+            .into_iter()
+            .map(|v| {
+                v.as_f64()
+                    .map(|num| num as f32)
+                    .ok_or_else(|| "embedding must be an array of numbers".to_string())
+            })
+            .collect(),
+        _ => Err("embedding must be an array of numbers".to_string()),
     }
 }
 
-async fn handle_upsert(Json(payload): Json<UpsertRequest>) -> Json<serde_json::Value> {
-    // TODO: wire up embeddings + HNSW persistence.
-    info!(doc_id = %payload.doc_id, chunks = payload.chunks.len(), "received upsert");
-    Json(serde_json::json!({
-        "status": "accepted",
-        "chunks": payload.chunks.len(),
-    }))
-}
-
-async fn handle_delete(Json(payload): Json<DeleteRequest>) -> Json<serde_json::Value> {
-    info!(doc_id = %payload.doc_id, "received delete");
-    Json(serde_json::json!({
-        "status": "accepted"
-    }))
+fn bad_request(message: impl Into<String>) -> (StatusCode, Json<Value>) {
+    let body = json!({
+        "error": message.into(),
+    });
+    (StatusCode::BAD_REQUEST, Json(body))
 }
 
 async fn handle_search(Json(payload): Json<SearchRequest>) -> Json<SearchResponse> {

--- a/crates/indexd/src/store.rs
+++ b/crates/indexd/src/store.rs
@@ -1,0 +1,93 @@
+use std::collections::HashMap;
+
+use serde_json::Value;
+use thiserror::Error;
+
+const KEY_SEPARATOR: &str = "\u{241F}";
+
+#[derive(Debug, Default)]
+pub struct VectorStore {
+    pub dims: Option<usize>,
+    pub items: HashMap<(String, String), (Vec<f32>, Value)>,
+}
+
+impl VectorStore {
+    pub fn new() -> Self {
+        Self {
+            dims: None,
+            items: HashMap::new(),
+        }
+    }
+
+    pub fn upsert(
+        &mut self,
+        namespace: &str,
+        doc_id: &str,
+        chunk_id: &str,
+        vector: Vec<f32>,
+        meta: Value,
+    ) -> Result<(), VectorStoreError> {
+        if let Some(expected) = self.dims {
+            if expected != vector.len() {
+                return Err(VectorStoreError::DimensionalityMismatch {
+                    expected,
+                    actual: vector.len(),
+                });
+            }
+        } else {
+            self.dims = Some(vector.len());
+        }
+
+        let key = (namespace.to_string(), make_chunk_key(doc_id, chunk_id));
+        self.items.insert(key, (vector, meta));
+        Ok(())
+    }
+
+    pub fn delete_doc(&mut self, namespace: &str, doc_id: &str) {
+        let prefix = format!("{doc_id}{KEY_SEPARATOR}");
+        self.items
+            .retain(|(ns, key), _| !(ns == namespace && key.starts_with(&prefix)));
+    }
+
+    pub fn all_in_namespace<'a>(
+        &'a self,
+        namespace: &'a str,
+    ) -> impl Iterator<Item = (&'a (String, String), &'a (Vec<f32>, Value))> + 'a {
+        self.items
+            .iter()
+            .filter(move |((ns, _), _)| ns == namespace)
+    }
+}
+
+#[derive(Debug, Error)]
+pub enum VectorStoreError {
+    #[error("embedding dimensionality mismatch: expected {expected}, got {actual}")]
+    DimensionalityMismatch { expected: usize, actual: usize },
+}
+
+fn make_chunk_key(doc_id: &str, chunk_id: &str) -> String {
+    format!("{doc_id}{KEY_SEPARATOR}{chunk_id}")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn upsert_delete_smoke() {
+        let mut store = VectorStore::new();
+        let meta = Value::Null;
+        store
+            .upsert("namespace", "doc", "chunk-1", vec![0.1, 0.2], meta.clone())
+            .expect("first insert sets dims");
+        store
+            .upsert("namespace", "doc", "chunk-2", vec![0.3, 0.4], meta)
+            .expect("second insert matches dims");
+
+        assert_eq!(store.items.len(), 2);
+
+        store.delete_doc("namespace", "doc");
+
+        assert!(store.items.is_empty(), "store should be empty after delete");
+    }
+}

--- a/crates/indexd/tests/healthz.rs
+++ b/crates/indexd/tests/healthz.rs
@@ -1,0 +1,27 @@
+use std::sync::Arc;
+
+use axum::{
+    body::{to_bytes, Body},
+    http::{Request, StatusCode},
+};
+use tower::ServiceExt;
+
+#[tokio::test]
+async fn healthz_returns_ok() {
+    let app = indexd::router(Arc::new(indexd::AppState::new()));
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .uri("/healthz")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let body = to_bytes(response.into_body(), 1024).await.unwrap();
+    assert_eq!(body.as_ref(), b"ok");
+}


### PR DESCRIPTION
## Summary
- add shared application state, server bootstrap, and `/healthz` route that binds indexd on port 8080
- implement an in-memory vector store for chunk embeddings with dimensionality validation
- update the index handlers to use the shared store and validate embedding payloads
- update the `/healthz` integration test to construct the router with shared state and add the tower dev-dependency

## Testing
- cargo test -p indexd

------
https://chatgpt.com/codex/tasks/task_e_68e51b6bef5c832ca88275f5bb490392