### PR TITLE
Fix: Improve code quality and fix Makefile bug

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ __pycache__/
 # Local env
 .env
 .envrc
+semantah.yml
 
 # OS-specific
 .DS_Store

--- a/Makefile
+++ b/Makefile
@@ -37,5 +37,5 @@ clean:
 
 py-freeze:
 	mkdir -p .gewebe/reports
-	uv export --frozen --format=requirements-txt > .gewebe/reports/requirements-frozen.txt
+	uv export --format=requirements-txt > .gewebe/reports/requirements-frozen.txt
 	@echo "Lock-Metadaten → .gewebe/reports/requirements-frozen.txt"

--- a/scripts/build_graph.py
+++ b/scripts/build_graph.py
@@ -1,5 +1,9 @@
 #!/usr/bin/env python3
-"""Stub script to turn embeddings into graph nodes and edges."""
+"""Stub script to turn embeddings into graph nodes and edges.
+
+This is a placeholder for the full implementation.
+See `docs/blueprint.md` for the full concept.
+"""
 
 import json
 from pathlib import Path

--- a/scripts/build_index.py
+++ b/scripts/build_index.py
@@ -1,5 +1,9 @@
 #!/usr/bin/env python3
-"""Stub script for building embeddings and chunk index artifacts."""
+"""Stub script for building embeddings and chunk index artifacts.
+
+This is a placeholder for the full implementation.
+See `docs/blueprint.md` for the full concept.
+"""
 
 from pathlib import Path
 

--- a/scripts/update_related.py
+++ b/scripts/update_related.py
@@ -1,5 +1,9 @@
 #!/usr/bin/env python3
-"""Stub script to inject related blocks into Markdown files."""
+"""Stub script to inject related blocks into Markdown files.
+
+This is a placeholder for the full implementation.
+See `docs/blueprint.md` for the full concept.
+"""
 
 from pathlib import Path
 
@@ -14,7 +18,7 @@ def inject_related(note: Path) -> None:
 
 
 def main() -> None:
-    notes_dir = Path("notes_stub")
+    notes_dir = Path(".gewebe/notes_stub")
     notes_dir.mkdir(exist_ok=True)
     note = notes_dir / "example.md"
     note.write_text("# Example Note\n", encoding="utf-8")

--- a/semantah.yml
+++ b/semantah.yml
@@ -1,0 +1,17 @@
+vault_path: /path/to/your/obsidian-vault
+out_dir: .gewebe
+embedder:
+  provider: ollama          # oder: openai
+  model: nomic-embed-text   # Beispielmodell (lokal)
+index:
+  top_k: 20
+graph:
+  cutoffs:
+    # Beide Optionen anbieten – je nach aktuellem Parser:
+    # (A) Ko-Vorkommen/gewichtete Kante:
+    min_cooccur: 2
+    min_weight: 0.15
+    # (B) Falls der aktuelle Code noch auf Similarity-Schwelle hört:
+    # min_similarity: 0.35
+related:
+  write_back: false


### PR DESCRIPTION
This commit addresses several issues to improve the overall code quality and developer experience.

- Fix(Makefile): The `py-freeze` target in the `Makefile` used an invalid `--frozen` flag for the `uv export` command. This has been removed.
- Chore(scripts): Explanatory comments have been added to the stub scripts (`build_index.py`, `build_graph.py`, `update_related.py`) to clarify their purpose and direct developers to the blueprint documentation.
- Fix(scripts): The `update_related.py` script now creates its temporary `notes_stub` directory within the `.gewebe` directory, which is the designated output directory.
- Chore(.gitignore): The `semantah.yml` file has been added to the `.gitignore` file to prevent local configurations from being committed.