### PR TITLE
semantAH: minimal ingest from leitstand + validation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # Build artefacts & caches
 /target/
 .gewebe/
+vault/.gewebe/
 .pytest_cache/
 .ruff_cache/
 .mypy_cache/

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: uv-sync venv sync index graph related all demo clean py-freeze
+.PHONY: uv-sync venv sync index graph related all demo clean py-freeze insights-today
 
 UV := $(shell command -v uv 2>/dev/null)
 ifeq ($(UV),)
@@ -22,6 +22,13 @@ related:
 	uv run scripts/update_related.py
 
 all: uv-sync index graph related
+
+.PHONY: insights-today
+insights-today:
+	@test -f leitstand/data/aussen.jsonl || { echo "fehlend: leitstand/data/aussen.jsonl"; exit 1; }
+	uv run cli/ingest_leitstand.py leitstand/data/aussen.jsonl
+	@command -v npx >/dev/null 2>&1 || { echo "Node/npx fehlt (für ajv-cli)"; exit 1; }
+	npx -y ajv-cli@5 validate -s contracts/insights.schema.json -d vault/.gewebe/insights/today.json
 
 .PHONY: demo
 demo:

--- a/README.md
+++ b/README.md
@@ -64,12 +64,17 @@ Für ein ausführliches Step-by-Step siehe **docs/quickstart.md**. Kurzform:
 4. **Pipeline laufen lassen**
    - `make all` (erstellt `.gewebe/`-Artefakte)
    - `make demo` (Mini-Demo auf Basis der Example-Konfig)
-5. **Service testen**
+5. **Leitstand-Insights exportieren (read-only)**
+   - `uv run cli/ingest_leitstand.py leitstand/data/aussen.jsonl`
+   - Ergebnis: `vault/.gewebe/insights/today.json` (≤ 10 KB)
+   - Validierung: `npx -y ajv-cli@5 validate -s contracts/insights.schema.json -d vault/.gewebe/insights/today.json`
+   - Shortcut: `make insights-today`
+6. **Service testen**
    - `cargo run -p indexd`
 
 ## Export
 
-- Contracts: `contracts/semantics/*.schema.json`
+- Contracts: `contracts/semantics/*.schema.json`, `contracts/insights.schema.json`
 - Daten-Dumps (optional): `.gewebe/out/{nodes.jsonl,edges.jsonl,reports.json}` (JSONL pro Zeile).
 
 ## Status

--- a/cli/ingest_leitstand.py
+++ b/cli/ingest_leitstand.py
@@ -1,0 +1,183 @@
+#!/usr/bin/env python3
+"""Read Leitstand export and produce today's insights."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from collections import deque
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Iterable, List
+
+MAX_BYTES_DEFAULT = 10 * 1024
+DEFAULT_LIMIT = 32
+
+
+@dataclass
+class Insight:
+    tags: List[str]
+    title: str
+    summary: str
+    url: str
+
+    @classmethod
+    def from_record(cls, record: dict) -> "Insight | None":
+        title = _coerce_str(record.get("title"))
+        summary = _coerce_str(record.get("summary"))
+        url = _coerce_str(record.get("url"))
+        if not (title and summary and url):
+            return None
+
+        tags = _coerce_tags(record.get("tags"))
+        return cls(tags=tags, title=title, summary=summary, url=url)
+
+    def to_dict(self) -> dict:
+        return {
+            "tags": self.tags,
+            "title": self.title,
+            "summary": self.summary,
+            "url": self.url,
+        }
+
+
+def _coerce_str(value) -> str | None:
+    if value is None:
+        return None
+    if isinstance(value, str):
+        text = value.strip()
+        return text or None
+    return str(value)
+
+
+def _coerce_tags(value) -> List[str]:
+    if isinstance(value, str):
+        value = [value]
+    if not isinstance(value, Iterable) or isinstance(value, (bytes, bytearray)):
+        return []
+    tags = []
+    for item in value:
+        if item is None:
+            continue
+        text = str(item).strip()
+        if text:
+            tags.append(text)
+    return tags
+
+
+def read_last_records(path: Path, limit: int) -> list[dict]:
+    lines = deque(maxlen=limit)
+    with path.open("r", encoding="utf-8") as handle:
+        for raw_line in handle:
+            line = raw_line.strip()
+            if not line:
+                continue
+            lines.append(line)
+    records: list[dict] = []
+    for line in lines:
+        try:
+            records.append(json.loads(line))
+        except json.JSONDecodeError as exc:
+            raise ValueError(f"Cannot parse line as JSON: {line[:80]}...") from exc
+    return records
+
+
+def shrink_to_size(payload: dict, max_bytes: int) -> dict:
+    """Drop oldest items until serialized payload fits into max_bytes."""
+    items = payload.get("items", [])
+    if not isinstance(items, list):
+        return payload
+
+    encoded = _encode(payload)
+    while len(encoded) > max_bytes and items:
+        items.pop(0)
+        encoded = _encode(payload)
+    if len(encoded) > max_bytes:
+        raise ValueError(
+            "Unable to satisfy max-bytes constraint even after dropping all items"
+        )
+    return payload
+
+
+def _encode(payload: dict) -> bytes:
+    return json.dumps(payload, ensure_ascii=False, separators=(",", ":")).encode("utf-8")
+
+
+def build_payload(insights: list[Insight]) -> dict:
+    return {
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "source": "leitstand",
+        "items": [insight.to_dict() for insight in insights],
+    }
+
+
+def ingest(args: argparse.Namespace) -> Path:
+    source_path = Path(args.source).expanduser().resolve()
+    output_path = Path(args.output).expanduser()
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+
+    if not source_path.is_file():
+        raise FileNotFoundError(f"Source file not found: {source_path}")
+
+    raw_records = read_last_records(source_path, args.limit)
+    insights = []
+    for record in raw_records:
+        insight = Insight.from_record(record)
+        if insight is not None:
+            insights.append(insight)
+
+    payload = build_payload(insights)
+    shrink_to_size(payload, args.max_bytes)
+
+    data_bytes = _encode(payload)
+    output_path.write_bytes(data_bytes)
+    return output_path
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Read Leitstand JSONL export and store the latest insights in "
+            "vault/.gewebe/insights/today.json"
+        )
+    )
+    parser.add_argument(
+        "source",
+        help="Path to leitstand/data/aussen.jsonl",
+    )
+    parser.add_argument(
+        "--output",
+        default="vault/.gewebe/insights/today.json",
+        help="Target JSON file (default: vault/.gewebe/insights/today.json)",
+    )
+    parser.add_argument(
+        "--limit",
+        type=int,
+        default=DEFAULT_LIMIT,
+        help=f"Number of trailing records to read (default: {DEFAULT_LIMIT})",
+    )
+    parser.add_argument(
+        "--max-bytes",
+        type=int,
+        default=MAX_BYTES_DEFAULT,
+        help="Maximum JSON payload size in bytes (default: 10240)",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    try:
+        args = parse_args(argv)
+        output_path = ingest(args)
+    except Exception as exc:  # pragma: no cover - small CLI
+        print(f"Error: {exc}", file=sys.stderr)
+        return 1
+
+    print(output_path)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/contracts/insights.schema.json
+++ b/contracts/insights.schema.json
@@ -1,0 +1,46 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Daily Insights",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["generated_at", "source", "items"],
+  "properties": {
+    "generated_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "source": {
+      "type": "string",
+      "minLength": 1
+    },
+    "items": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["title", "summary", "url", "tags"],
+        "properties": {
+          "title": {
+            "type": "string",
+            "minLength": 1
+          },
+          "summary": {
+            "type": "string",
+            "minLength": 1
+          },
+          "url": {
+            "type": "string",
+            "format": "uri"
+          },
+          "tags": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "minLength": 1
+            }
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add a Python CLI that reads the latest Leitstand JSONL items and emits `vault/.gewebe/insights/today.json`
- define a dedicated JSON schema for daily insights and wire it into the validation flow
- document the workflow in the README and provide a `make insights-today` target
- harden the `insights-today` flow with presence checks for the Leitstand dump and local `npx`, and ignore generated vault artefacts

## Testing
- `make insights-today` *(fails intentionally when `leitstand/data/aussen.jsonl` is absent to surface the guard)*

------
https://chatgpt.com/codex/tasks/task_e_68ee60cfa1d0832cb227aedf234763a8