### PR TITLE
Validate ingest CLI rejects non-object JSON records

### DIFF
--- a/cli/ingest_leitstand.py
+++ b/cli/ingest_leitstand.py
@@ -78,9 +78,14 @@ def read_last_records(path: Path, limit: int) -> list[dict]:
     records: list[dict] = []
     for line in lines:
         try:
-            records.append(json.loads(line))
+            record = json.loads(line)
         except json.JSONDecodeError as exc:
             raise ValueError(f"Cannot parse line as JSON: {line[:80]}...") from exc
+        if not isinstance(record, dict):
+            raise ValueError(
+                "Each JSONL record must be an object with insight fields"
+            )
+        records.append(record)
     return records
 
 


### PR DESCRIPTION
## Summary
- ensure the Leitstand ingest helper validates that every JSONL record is a JSON object
- raise a clear ValueError when encountering an unexpected record type instead of crashing later

## Testing
- python -m compileall cli/ingest_leitstand.py
- python cli/ingest_leitstand.py leitstand/data/aussen.jsonl


------
https://chatgpt.com/codex/tasks/task_e_68f31778ad24832cbba69859bcbf85f5