### PR TITLE
The `Justfile`'s `export-insights` recipe was outdated and used a non…

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -1,4 +1,3 @@
-export-insights:
-	VAULT_ROOT=${VAULT_ROOT:-~/Vaults/main}
-	@echo "Exporting insights to ${VAULT_ROOT}/.gewebe/insights/today.json"
-	VAULT_ROOT=${VAULT_ROOT} uv run scripts/export_insights.py
+ingest-leitstand:
+	@test -f leitstand/data/aussen.jsonl || { echo "fehlend: leitstand/data/aussen.jsonl"; exit 1; }
+	uv run cli/ingest_leitstand.py leitstand/data/aussen.jsonl


### PR DESCRIPTION
…-functional stub script. This commit updates the recipe to align with the `Makefile`, renaming it to `ingest-leitstand` for clarity and ensuring it executes the correct script, `cli/ingest_leitstand.py`, to process Leitstand data. This change resolves the inconsistency and makes the build tooling more reliable.