### PR TITLE
Fix ownership issue when saving vector store

### DIFF
--- a/crates/indexd/src/persist.rs
+++ b/crates/indexd/src/persist.rs
@@ -95,10 +95,11 @@ pub async fn maybe_save_from_env(state: &Arc<AppState>) -> anyhow::Result<()> {
         });
     }
 
+    let row_count = rows.len();
     let path_clone = path.clone();
     task::spawn_blocking(move || write_jsonl_atomic(&path_clone, &rows)).await??;
 
-    info!(path = %path.display(), count = rows.len(), "saved vector store");
+    info!(path = %path.display(), count = row_count, "saved vector store");
     Ok(())
 }
 


### PR DESCRIPTION
## Summary
- capture the row count before moving data into the blocking save task
- log the saved vector store without requiring additional cloning

## Testing
- cargo fmt

------
https://chatgpt.com/codex/tasks/task_e_68f4172147fc832c806c9a9d646f4e41