### PR TITLE
Fix update_related stub directory creation

### DIFF
--- a/scripts/update_related.py
+++ b/scripts/update_related.py
@@ -19,7 +19,7 @@ def inject_related(note: Path) -> None:
 
 def main() -> None:
     notes_dir = Path(".gewebe/notes_stub")
-    notes_dir.mkdir(exist_ok=True)
+    notes_dir.mkdir(parents=True, exist_ok=True)
     note = notes_dir / "example.md"
     note.write_text("# Example Note\n", encoding="utf-8")
     inject_related(note)


### PR DESCRIPTION
## Summary
- ensure the update_related stub creates the notes directory along with missing parents

## Testing
- python scripts/update_related.py
- python -m compileall scripts/update_related.py

------
https://chatgpt.com/codex/tasks/task_e_68f46b37818c832c9feaab31e716b9fa