### PR TITLE
docs: add embeddings and namespaces docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,9 @@ Es zerlegt Notizen (z. B. aus Obsidian), erstellt **Embeddings**, baut daraus ei
 - **KPIs:** Index-Suche top-k=20 in < 60 ms (p95).
 - **Integrationen:** Obsidian Canvas (Auto-Links), systemd-Timer, WGX-Recipes.
 
-Mehr zur Integration: [docs/hauski.md](docs/hauski.md).
+Mehr zur Integration: [docs/hauski.md](docs/hauski.md). Ergänzend:
+- Embeddings: siehe [`docs/embeddings.md`](docs/embeddings.md)
+- Namespaces: siehe [`docs/namespaces.md`](docs/namespaces.md)
 
 SemantAH ist eine lokal laufende Wissensgraph- und Semantik-Pipeline für Obsidian-Vaults. Das Projekt adaptiert die Blaupausen aus `semantAH.md` und `semantAH brainstorm.md` und zielt darauf ab, eine modulare, reproduzierbare Infrastruktur aufzubauen:
 

--- a/docs/embeddings.md
+++ b/docs/embeddings.md
@@ -1,0 +1,4 @@
+# Embeddings (Quelle & Normalisierung)
+- Provider: lokal (Ollama) oder extern (später).
+- Dimensionen: abhängig vom Modell; Vektoren normalisiert (L2) für Index.
+- Persistenz: `.gewebe/embeddings.parquet`.

--- a/docs/namespaces.md
+++ b/docs/namespaces.md
@@ -1,0 +1,3 @@
+# Namespaces
+- Zweck: Trennung von Datenräumen (z. B. `vault`, `web`, `notes:private`).
+- Default: `vault`. Konfigurierbar via `semantah.yml`.


### PR DESCRIPTION
## Summary
- add short documentation stubs for embeddings and namespaces under docs/
- reference the new documents from the README integration section

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68f5ea46356c832cbc3ac740bcf0c3e9