### PR TITLE
refactor(indexd): centralize chunk key logic

### DIFF
--- a/crates/indexd/src/key.rs
+++ b/crates/indexd/src/key.rs
@@ -1,0 +1,12 @@
+pub(crate) const KEY_SEPARATOR: &str = "\u{241F}";
+
+pub(crate) fn make_chunk_key(doc_id: &str, chunk_id: &str) -> String {
+    format!("{doc_id}{KEY_SEPARATOR}{chunk_id}")
+}
+
+pub(crate) fn split_chunk_key(key: &str) -> (String, String) {
+    match key.split_once(KEY_SEPARATOR) {
+        Some((doc_id, chunk_id)) => (doc_id.to_string(), chunk_id.to_string()),
+        None => (key.to_string(), String::new()),
+    }
+}

--- a/crates/indexd/src/lib.rs
+++ b/crates/indexd/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod api;
+mod key;
 mod persist;
 pub mod store;
 

--- a/crates/indexd/src/persist.rs
+++ b/crates/indexd/src/persist.rs
@@ -9,7 +9,7 @@ use serde_json::Value;
 use tokio::task;
 use tracing::{info, warn};
 
-use crate::AppState;
+use crate::{key::split_chunk_key, AppState};
 
 const ENV_DB_PATH: &str = "INDEXD_DB_PATH";
 
@@ -146,14 +146,6 @@ fn write_jsonl_atomic(path: &Path, rows: &[RowOwned]) -> anyhow::Result<()> {
 
     fs::rename(tmp, path)?;
     Ok(())
-}
-
-fn split_chunk_key(key: &str) -> (String, String) {
-    const SEP: char = '\u{241F}';
-    match key.split_once(SEP) {
-        Some((doc, chunk)) => (doc.to_string(), chunk.to_string()),
-        None => (key.to_string(), String::new()),
-    }
 }
 
 #[cfg(test)]

--- a/crates/indexd/src/store.rs
+++ b/crates/indexd/src/store.rs
@@ -4,7 +4,7 @@ use std::collections::HashMap;
 use serde_json::Value;
 use thiserror::Error;
 
-const KEY_SEPARATOR: &str = "\u{241F}";
+use crate::key::{make_chunk_key, split_chunk_key, KEY_SEPARATOR};
 
 #[derive(Debug, Default)]
 pub struct VectorStore {
@@ -114,17 +114,6 @@ impl VectorStore {
 pub enum VectorStoreError {
     #[error("embedding dimensionality mismatch: expected {expected}, got {actual}")]
     DimensionalityMismatch { expected: usize, actual: usize },
-}
-
-fn make_chunk_key(doc_id: &str, chunk_id: &str) -> String {
-    format!("{doc_id}{KEY_SEPARATOR}{chunk_id}")
-}
-
-fn split_chunk_key(key: &str) -> (String, String) {
-    match key.split_once(KEY_SEPARATOR) {
-        Some((doc_id, chunk_id)) => (doc_id.to_string(), chunk_id.to_string()),
-        None => (key.to_string(), String::new()),
-    }
 }
 
 fn dot(a: &[f32], b: &[f32]) -> f32 {


### PR DESCRIPTION
Refactored the duplicated `make_chunk_key` and `split_chunk_key` functions and the `KEY_SEPARATOR` constant from the `store` and `persist` modules into a new, dedicated `key` module.

This change eliminates code duplication, improving maintainability and reducing the risk of inconsistencies between the modules.