### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci-tools.yml
+++ b/.github/workflows/ci-tools.yml
@@ -1,4 +1,6 @@
 name: ci-tools
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/heimgewebe/semantAH/security/code-scanning/2](https://github.com/heimgewebe/semantAH/security/code-scanning/2)

To fix this issue, add a `permissions:` block explicitly limiting the generated GITHUB_TOKEN's granted permissions to only those required for the workflow. Since the workflow only reads repository contents (using `actions/checkout` and running scripts), the minimal permission set is `contents: read`. The root-level `permissions:` block (added after the workflow `name:` and before `jobs:`) will apply to all jobs unless they have their own `permissions:` block.  
Edit `.github/workflows/ci-tools.yml`:  
- Insert `permissions:\n  contents: read` after the `name: ci-tools` line (line 1 or 2) and before `on:`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
