### PR TITLE
Add write actions permission to ci-tools workflow

### DIFF
--- a/.github/workflows/ci-tools.yml
+++ b/.github/workflows/ci-tools.yml
@@ -1,6 +1,8 @@
 name: ci-tools
 permissions:
+  # Allow cache usage (requires actions: write)
   contents: read
+  actions: write
 
 on:
   push:


### PR DESCRIPTION
## Summary
- allow the ci-tools workflow to write to the Actions API so cache steps succeed

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f76138afbc832c89654036ef20c827