### PR TITLE
Restore push trigger for wgx-guard workflow

### DIFF
--- a/.github/workflows/wgx-guard.yml
+++ b/.github/workflows/wgx-guard.yml
@@ -3,6 +3,7 @@ permissions:
   contents: read
 
 on:
+  push:
     paths:
       - ".wgx/**"
       - ".github/workflows/wgx-guard.yml"


### PR DESCRIPTION
## Summary
- restore the push trigger for the wgx-guard workflow while retaining the read-only permissions block
- ensure push and pull_request triggers monitor the workflow file, Cargo manifest, and pyproject

## Testing
- not run (CI only)


------
https://chatgpt.com/codex/tasks/task_e_68f761746958832c8ec5655a0741a194