### PR TITLE
Rename OS embedding doc to mitschreiber index

### DIFF
--- a/docs/mitschreiber-index.md
+++ b/docs/mitschreiber-index.md
@@ -1,0 +1,23 @@
+# semantAH: Mitschreiber-Index
+
+Semantische Suche über Kontext-Embeddings aus mitschreiber.
+
+## Index
+- Name: `idx_os_embed`
+- Space: cosine
+- Payload: `app`, `window`, `keyphrases[]`, `hash_id`
+
+## Ingest
+- Quelle: leitstand (ETL/Stream)
+- Dedup: über `hash_id`
+
+## Realtime
+- Optional: lokaler Websocket/IPC vom mitschreiber (nur im RAM) für “contextual candidates”.
+
+## Query-Operatoren (Beispiele)
+- `near:("oauth flow") app:code window:projX`
+- `since:7d mode:deepwork`
+
+## Datenschutz
+- **Kein Rohtext** im Index.
+- `privacy.raw_retained=false` im Payload.


### PR DESCRIPTION
## Summary
- rename the OS embedding index documentation file to `mitschreiber-index.md`
- update the page heading to match the new name

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f87fd6198c832cb5aecbc6f9c82e74