### PR TITLE
Make push-index target use script entrypoint

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: uv-sync venv sync index graph related all demo clean py-freeze insights-today
+.PHONY: uv-sync venv sync index graph related push-index all demo clean py-freeze insights-today
 
 UV := $(shell command -v uv 2>/dev/null)
 ifeq ($(UV),)
@@ -20,6 +20,9 @@ graph:
 
 related:
 	uv run scripts/update_related.py
+
+push-index:
+	uv run scripts/push_index.py
 
 all: uv-sync index graph related
 

--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ Für ein ausführliches Step-by-Step siehe **docs/quickstart.md**. Kurzform:
    - `cp examples/semantah.example.yml semantah.yml` → Pfade anpassen
 4. **Pipeline laufen lassen**
    - `make all` (erstellt `.gewebe/`-Artefakte)
+   - `make push-index` (schiebt vorhandene Embeddings zu indexd)
    - `make demo` (Mini-Demo auf Basis der Example-Konfig)
 5. **Leitstand-Insights exportieren (read-only)**
    - `uv run cli/ingest_leitstand.py leitstand/data/aussen.jsonl`

--- a/scripts/push_index.py
+++ b/scripts/push_index.py
@@ -1,0 +1,264 @@
+#!/usr/bin/env python3
+"""Push embeddings from `.gewebe/embeddings.parquet` to the local indexd service."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import sys
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Tuple
+from urllib import error, request
+
+import pandas as pd
+
+try:  # NumPy ist optional, hilft aber beim Typ-Check der Embeddings
+    import numpy as np  # type: ignore
+except Exception:  # pragma: no cover - fallback ohne NumPy
+    np = None  # type: ignore
+
+DEFAULT_EMBEDDINGS = Path(".gewebe/embeddings.parquet")
+DEFAULT_ENDPOINT = "http://localhost:8080/index/upsert"
+DEFAULT_NAMESPACE = "vault"
+DEFAULT_TIMEOUT = 10.0
+DEFAULT_RETRIES = 2
+DEFAULT_MAX_CHUNKS = 500
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Push vorhandene Embeddings in indexd.")
+    parser.add_argument(
+        "--embeddings",
+        type=Path,
+        default=DEFAULT_EMBEDDINGS,
+        help="Pfad zur embeddings.parquet-Datei",
+    )
+    parser.add_argument(
+        "--endpoint",
+        default=DEFAULT_ENDPOINT,
+        help="HTTP-Endpunkt von indexd (/index/upsert)",
+    )
+    parser.add_argument(
+        "--namespace",
+        default=DEFAULT_NAMESPACE,
+        help="Fallback-Namespace, falls keiner in den Daten vorhanden ist.",
+    )
+    parser.add_argument(
+        "--timeout",
+        type=float,
+        default=DEFAULT_TIMEOUT,
+        help=f"HTTP-Timeout in Sekunden (default: {DEFAULT_TIMEOUT})",
+    )
+    parser.add_argument(
+        "--retries",
+        type=int,
+        default=DEFAULT_RETRIES,
+        help=f"HTTP-Retries bei Fehlern (default: {DEFAULT_RETRIES})",
+    )
+    parser.add_argument(
+        "--max-chunks",
+        type=int,
+        default=DEFAULT_MAX_CHUNKS,
+        help=f"Max. Chunks pro Upsert-Request (default: {DEFAULT_MAX_CHUNKS})",
+    )
+    return parser.parse_args()
+
+
+def to_batches(df: pd.DataFrame, default_namespace: str) -> Iterable[Dict[str, Any]]:
+    """Gruppiert DataFrame-Zeilen zu Upsert-Batches."""
+
+    records = df.to_dict(orient="records")
+    grouped: Dict[Tuple[str, str], Dict[str, Any]] = {}
+
+    for record in records:
+        doc_id = _derive_doc_id(record)
+        namespace = str(record.get("namespace") or default_namespace)
+        key = (namespace, doc_id)
+        batch = grouped.setdefault(
+            key,
+            {
+                "doc_id": doc_id,
+                "namespace": namespace,
+                "chunks": [],
+            },
+        )
+        batch["chunks"].append(_record_to_chunk(record, doc_id))
+
+    return grouped.values()
+
+
+def _derive_doc_id(record: Dict[str, Any]) -> str:
+    for key in ("doc_id", "path", "id"):
+        value = record.get(key)
+        if value:
+            return str(value)
+    raise ValueError("Record without doc identifier")
+
+
+def _record_to_chunk(record: Dict[str, Any], doc_id: str) -> Dict[str, Any]:
+    chunk_id = record.get("id") or _compose_chunk_id(doc_id, record.get("chunk_id"))
+    text = str(record.get("text") or "")
+    embedding = _to_embedding(record.get("embedding"))
+
+    meta: Dict[str, Any] = {"embedding": embedding}
+
+    # Zusätzliche Metadaten mitschicken (falls vorhanden)
+    for key, value in record.items():
+        if key in {"embedding", "text", "doc_id", "namespace", "id"}:
+            continue
+        if _is_missing(value):
+            continue
+        if key == "path":
+            meta["source_path"] = str(value)
+            continue
+        if key == "chunk_id":
+            try:
+                meta["chunk_id"] = int(value)
+            except Exception:
+                meta["chunk_id"] = value
+            continue
+        meta[key] = _normalise_meta_value(value)
+
+    return {"id": str(chunk_id), "text": text, "meta": meta}
+
+
+def _compose_chunk_id(doc_id: str, chunk_suffix: Any) -> str:
+    if _is_missing(chunk_suffix):
+        return str(doc_id)
+    if isinstance(chunk_suffix, (int, float)) and not math.isnan(float(chunk_suffix)):
+        suffix = int(chunk_suffix)
+    else:
+        suffix = chunk_suffix
+    return f"{doc_id}#{suffix}"
+
+
+def _to_embedding(value: Any) -> List[float]:
+    if value is None:
+        raise ValueError("Missing embedding in record")
+    if hasattr(value, "tolist"):
+        value = value.tolist()
+    if np is not None and isinstance(value, np.ndarray):  # type: ignore[arg-type]
+        value = value.tolist()
+    if not isinstance(value, (list, tuple)):
+        raise TypeError(f"Unexpected embedding type: {type(value)!r}")
+    return [float(x) for x in value]
+
+
+def _is_missing(value: Any) -> bool:
+    if value is None:
+        return True
+    if isinstance(value, float) and math.isnan(value):
+        return True
+    try:
+        result = pd.isna(value)
+    except Exception:
+        return False
+    else:
+        if isinstance(result, bool):
+            return result
+        if hasattr(result, "all"):
+            try:
+                return bool(result.all())
+            except Exception:
+                return False
+    return False
+
+
+def _normalise_meta_value(value: Any) -> Any:
+    if isinstance(value, Path):
+        return str(value)
+    if hasattr(value, "tolist"):
+        return value.tolist()  # type: ignore[no-any-return]
+    if isinstance(value, (pd.Timestamp,)):
+        return value.isoformat()
+    if hasattr(value, "item"):
+        try:
+            return value.item()  # type: ignore[no-any-return]
+        except Exception:
+            pass
+    return value
+
+
+def _split_batch(batch: Dict[str, Any], max_chunks: int) -> Iterable[Dict[str, Any]]:
+    chunks = batch["chunks"]
+    if len(chunks) <= max_chunks:
+        yield batch
+        return
+
+    for offset in range(0, len(chunks), max_chunks):
+        yield {
+            "doc_id": batch["doc_id"],
+            "namespace": batch["namespace"],
+            "chunks": chunks[offset : offset + max_chunks],
+        }
+
+
+def post_upsert(
+    endpoint: str, payload: Dict[str, Any], *, timeout: float
+) -> Dict[str, Any] | None:
+    data = json.dumps(payload).encode("utf-8")
+    req = request.Request(endpoint, data=data, headers={"Content-Type": "application/json"})
+    with request.urlopen(req, timeout=timeout) as resp:
+        body = resp.read().decode("utf-8").strip()
+        if not body:
+            return None
+        return json.loads(body)
+
+
+def main() -> int:
+    args = parse_args()
+
+    if not args.embeddings.exists():
+        print(f"[push-index] Fehlend: {args.embeddings}", file=sys.stderr)
+        return 1
+
+    try:
+        df = pd.read_parquet(args.embeddings)
+    except Exception as exc:  # pragma: no cover - IO-Fehler
+        print(f"[push-index] Konnte {args.embeddings} nicht lesen: {exc}", file=sys.stderr)
+        return 1
+
+    if df.empty:
+        print("[push-index] Keine Embeddings gefunden — nichts zu tun.")
+        return 0
+
+    batches = list(to_batches(df, args.namespace))
+    if not batches:
+        print("[push-index] Keine gültigen Batches erzeugt.", file=sys.stderr)
+        return 1
+
+    for batch in batches:
+        for sub_batch in _split_batch(batch, args.max_chunks):
+            for attempt in range(args.retries + 1):
+                try:
+                    response = post_upsert(args.endpoint, sub_batch, timeout=args.timeout)
+                except error.HTTPError as exc:
+                    if attempt >= args.retries:
+                        print(
+                            f"[push-index] HTTP-Fehler für doc={sub_batch['doc_id']} namespace={sub_batch['namespace']}: {exc}",
+                            file=sys.stderr,
+                        )
+                        return 1
+                    continue
+                except error.URLError as exc:
+                    if attempt >= args.retries:
+                        print(
+                            f"[push-index] Konnte {args.endpoint} nicht erreichen: {exc.reason}",
+                            file=sys.stderr,
+                        )
+                        return 1
+                    continue
+                else:
+                    chunks = len(sub_batch["chunks"])
+                    status = response.get("status") if isinstance(response, dict) else "ok"
+                    print(
+                        f"[push-index] Upsert gesendet • doc={sub_batch['doc_id']} namespace={sub_batch['namespace']} chunks={chunks} status={status}",
+                    )
+                    break
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- invoke the push-index make target via the script entrypoint so it matches other uv helpers
- document the new push-index helper in the quickstart so contributors discover it easily
- ensure the push_index script is executable for direct use under uv

## Testing
- uv run scripts/push_index.py --help

------
https://chatgpt.com/codex/tasks/task_e_68fdb42c21dc832ca682639c582c20d0