### PR TITLE
Support embeddings in query metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,14 @@ curl -sS localhost:8080/index/upsert \
   -d '{
     "doc_id":"note-1",
     "namespace":"vault",
-    "chunks":[{"id":"c1","text":"Hello world","meta":{"embedding":[0.1,0.2,0.3],"snippet":"Hello world"}}]
+    "chunks":[{
+      "id":"c1",
+      "text":"Hello world",
+      "meta":{
+        "embedding":[0.1,0.2,0.3],
+        "snippet":"Hello world"
+      }
+    }]
   }'
 ```
 
@@ -93,8 +100,20 @@ Search (Embedding vorerst Pflicht)
 ```bash
 curl -sS localhost:8080/index/search \
   -H 'content-type: application/json' \
-  -d '{"query":"hello","k":5,"namespace":"vault","embedding":[0.1,0.2,0.3]}'
+  -d '{
+    "query":{
+      "text":"hello",
+      "meta":{
+        "embedding":[0.1,0.2,0.3]
+      }
+    },
+    "k":5,
+    "namespace":"vault"
+  }'
 ```
+
+Legacy-Clients dürfen das Feld `embedding` auch auf Top-Level setzen.
+Fehlt `query.meta.embedding`, wird der Top-Level-Wert verwendet.
 
 ### Persistenz (optional)
 

--- a/crates/indexd/tests/search.rs
+++ b/crates/indexd/tests/search.rs
@@ -36,10 +36,74 @@ async fn upsert_then_search_returns_hit() {
     assert!(response.status().is_success());
 
     let search_payload = json!({
+        "query": {
+            "text": "hello",
+            "meta": {"embedding": [1.0, 0.0]}
+        },
+        "k": 5,
+        "namespace": "ns"
+    });
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .uri("/index/search")
+                .method("POST")
+                .header("content-type", "application/json")
+                .body(Body::from(search_payload.to_string()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert!(response.status().is_success());
+
+    let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+    let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+
+    let results = json["results"]
+        .as_array()
+        .expect("results should be an array");
+    assert_eq!(results.len(), 1);
+    assert_eq!(results[0]["doc_id"], "d1");
+    assert_eq!(results[0]["chunk_id"], "c1");
+}
+
+#[tokio::test]
+async fn upsert_then_search_with_top_level_embedding_returns_hit() {
+    let state = Arc::new(AppState::new());
+    let app = api::router(state.clone());
+
+    let upsert_payload = json!({
+        "doc_id": "d1",
+        "namespace": "ns",
+        "chunks": [{
+            "id": "c1",
+            "text": "hello",
+            "meta": {"embedding": [1.0, 0.0], "snippet": "hello"}
+        }]
+    });
+
+    let response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .uri("/index/upsert")
+                .method("POST")
+                .header("content-type", "application/json")
+                .body(Body::from(upsert_payload.to_string()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert!(response.status().is_success());
+
+    let search_payload = json!({
         "query": "hello",
         "k": 5,
         "namespace": "ns",
-        "meta": {"embedding": [1.0, 0.0]}
+        "embedding": [1.0, 0.0]
     });
 
     let response = app

--- a/docs/indexd-api.md
+++ b/docs/indexd-api.md
@@ -42,7 +42,20 @@ Lokale Entwicklungsumgebungen laufen ohne Authentifizierung. Für produktive Set
 
 ### `POST /index/search`
 - **Zweck:** Führt eine vektorbasierte Suche aus.
-- **Body:** `{ "query": "backup policy", "namespace": "vault", "k": 10, "filters": { "tags": ["policy"] } }`
+  - **Body:**
+  ```json
+  {
+    "query": {
+      "text": "backup policy",
+      "meta": {
+        "embedding": [0.12, 0.98]
+      }
+    },
+    "namespace": "vault",
+    "k": 10,
+    "filters": { "tags": ["policy"] }
+  }
+  ```
 - **Antwort:**
   ```json
   {
@@ -57,6 +70,8 @@ Lokale Entwicklungsumgebungen laufen ohne Authentifizierung. Für produktive Set
     ]
   }
   ```
+  Legacy-Clients können das Feld `embedding` weiterhin auf Top-Level senden.
+  Falls sowohl `query.meta.embedding` als auch `embedding` vorhanden sind, gewinnt der Wert aus dem Meta-Objekt.
   Aktuell liefert der Stub eine leere Trefferliste; das Schema ist dennoch stabil und kann für Clients genutzt werden.
 
 ### `GET /healthz`
@@ -79,7 +94,14 @@ curl -X POST http://localhost:8080/index/upsert \
 
 curl -X POST http://localhost:8080/index/search \
   -H 'Content-Type: application/json' \
-  -d '{"query":"backup","namespace":"vault","k":5}'
+  -d '{
+        "query": {
+          "text": "backup",
+          "meta": { "embedding": [0.1, 0.2] }
+        },
+        "namespace": "vault",
+        "k": 5
+      }'
 ```
 
 ## Logging & Observability

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -20,6 +20,34 @@ cp examples/semantah.example.yml semantah.yml
 make all           # embeddings → index → graph → related
 cargo run -p indexd
 curl -fsS localhost:8080/healthz || true
+
+# Index-Stubs registrieren (Embeddings im Meta-Objekt)
+curl -sS localhost:8080/index/upsert \
+  -H 'content-type: application/json' \
+  -d '{
+    "doc_id": "demo-note",
+    "namespace": "vault",
+    "chunks": [{
+      "id": "demo-note#0",
+      "text": "Hello demo",
+      "meta": {
+        "embedding": [0.1, 0.2, 0.3],
+        "snippet": "Hello demo"
+      }
+    }]
+  }'
+
+# Smoke-Test: Suche mit query.meta.embedding (liefert ggf. leere Treffer)
+curl -sS localhost:8080/index/search \
+  -H 'content-type: application/json' \
+  -d '{
+    "query": {
+      "text": "hello",
+      "meta": { "embedding": [0.1, 0.2, 0.3] }
+    },
+    "namespace": "vault",
+    "k": 5
+  }'
 ```
 
 Weitere Details:


### PR DESCRIPTION
## Summary
- allow the search endpoint to accept embeddings supplied in query metadata or via the legacy top-level field
- refresh README, quickstart, and API docs to illustrate the expanded JSON structure
- add guidance about the top-level embedding fallback for legacy clients

## Testing
- cargo test -p indexd

------
https://chatgpt.com/codex/tasks/task_e_68fdb6d69194832cb8420db4781e3a68