### PR TITLE
Restore deterministic chunk IDs and add property tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,7 +111,22 @@ jobs:
       - name: Sync env
         run: uv sync --frozen
 
+      - name: Ensure pytest-cov available (bootstrap-in-CI only)
+        run: |
+          uv run python - <<'PY'
+          import sys, subprocess
+          try:
+              import pytest_cov, coverage  # noqa: F401
+              import hypothesis  # noqa: F401
+              print("pytest-cov, coverage & hypothesis already present")
+          except Exception:
+              print("Installing pytest-cov, coverage & hypothesis just for CI…")
+              subprocess.check_call([sys.executable, "-m", "pip", "install", "pytest-cov", "coverage", "hypothesis"])
+          PY
+
       - name: Tests
+        env:
+          HYPOTHESIS_PROFILE: ci
         run: uv run pytest -q
 
       - name: Demo run (no network)

--- a/README.md
+++ b/README.md
@@ -75,6 +75,42 @@ Für ein ausführliches Step-by-Step siehe **docs/quickstart.md**. Kurzform:
 6. **Service testen**
    - `cargo run -p indexd`
 
+### Tests & Coverage (Python)
+
+Lokal kannst du die Test-Extras mit `uv` aktivieren:
+
+```bash
+uv sync -E test
+uv run pytest
+```
+
+Oder bequem per `make`:
+
+```bash
+# Unit-Tests (ohne @integration)
+make test
+# Coverage-Report unter ./reports/
+make coverage
+# Integration-Tests (mit @integration)
+make test-integration
+```
+
+> ℹ️ Setze `HYPOTHESIS_PROFILE=ci`, um lokal das deterministische Hypothesis-Profil der CI zu nutzen.
+
+Rust-Shortcuts:
+
+```bash
+# Tests (alle Crates)
+make test-rust
+
+# Lint (Clippy, bricht bei Warnungen ab)
+make lint-rust
+
+# Coverage (cargo llvm-cov; erzeugt LCOV bzw. HTML)
+make cov-rust         # -> reports/rust-lcov.info
+make cov-rust-html    # -> reports/llvm-cov/index.html
+```
+
 ### Beispiele: Index & Suche
 
 Upsert

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,3 +9,20 @@ dependencies = [
     "pyarrow",
     "pyyaml",
 ]
+
+[project.optional-dependencies]
+test = [
+    "pytest>=7.0",
+    "pytest-cov>=4.1",
+    "coverage>=7.5",
+    "hypothesis>=6.100",
+]
+
+[tool.pytest.ini_options]
+addopts = "-q"
+markers = [
+    "integration: marks tests as integration tests (deselect with '-m \"not integration\"')",
+]
+
+[tool.coverage.run]
+branch = true

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,17 @@
+import os
+
+try:
+    from hypothesis import settings
+    from hypothesis.errors import InvalidArgument
+except Exception:  # pragma: no cover - hypothesis optional in some environments
+    settings = None
+else:
+    try:
+        settings.register_profile(
+            "ci",
+            settings(max_examples=100, deadline=None, derandomize=True),
+        )
+    except InvalidArgument:
+        # Profile bereits gesetzt (z. B. bei mehrfacher Test-Session)
+        pass
+    settings.load_profile(os.getenv("HYPOTHESIS_PROFILE", "default"))

--- a/tests/test_push_index_property.py
+++ b/tests/test_push_index_property.py
@@ -1,0 +1,103 @@
+import collections
+from typing import Any, Dict, List, Tuple
+
+import pandas as pd
+import pytest
+
+hypothesis = pytest.importorskip("hypothesis")
+from hypothesis import given, settings, strategies as st  # type: ignore
+
+from scripts.push_index import to_batches
+
+
+def _entries_from_batches(batches: List[Dict[str, Any]]) -> List[Tuple[str, str, str, str]]:
+    """Flacht die Batches auf (namespace, doc_id, chunk_id, text)."""
+
+    flattened: List[Tuple[str, str, str, str]] = []
+    for batch in batches:
+        namespace = str(batch["namespace"])
+        doc_id = str(batch["doc_id"])
+        for chunk in batch["chunks"]:
+            chunk_id = str(chunk["id"])
+            text = str(chunk.get("text", ""))
+            flattened.append((namespace, doc_id, chunk_id, text))
+    return flattened
+
+
+_namespace_strategy = st.one_of(
+    st.none(),
+    st.floats(allow_nan=True),
+    st.just(""),
+    st.just("   "),
+    st.text(min_size=1, max_size=8),
+)
+
+_doc_id_strategy = st.text(min_size=1, max_size=8)
+
+_maybe_chunk_id = st.one_of(
+    st.none(),
+    st.booleans(),
+    st.text(min_size=1, max_size=8),
+)
+
+_text_strategy = st.text(min_size=1, max_size=32)
+
+_embedding_strategy = st.lists(
+    st.floats(allow_nan=False, allow_infinity=False, width=16), min_size=2, max_size=2
+)
+
+_record_strategy = st.fixed_dictionaries(
+    {
+        "doc_id": _doc_id_strategy,
+        "namespace": _namespace_strategy,
+        "chunk_id": _maybe_chunk_id,
+        "id": st.none(),
+        "text": _text_strategy,
+        "embedding": _embedding_strategy,
+    }
+)
+
+
+def _counter(entries: List[Tuple[str, str, str, str]]) -> collections.Counter:
+    return collections.Counter(entries)
+
+
+@settings(max_examples=100, deadline=None)
+@given(st.lists(_record_strategy, min_size=1, max_size=8))
+def test_chunk_ids_stable_across_permutations(records: List[Dict[str, Any]]):
+    """Chunk-IDs bleiben bei unterschiedlichen Reihenfolgen stabil."""
+
+    default_namespace = "ns-default"
+
+    df = pd.DataFrame(records)
+    baseline_entries = _entries_from_batches(list(to_batches(df, default_namespace=default_namespace)))
+    baseline_counter = _counter(baseline_entries)
+    assert all("nan" not in chunk_id.lower() for (_, _, chunk_id, _) in baseline_entries)
+
+    shuffled_df = df.sample(frac=1.0, random_state=123).reset_index(drop=True)
+    reversed_df = df.iloc[::-1].reset_index(drop=True)
+
+    for dframe in (shuffled_df, reversed_df):
+        entries = _entries_from_batches(list(to_batches(dframe, default_namespace=default_namespace)))
+        counter = _counter(entries)
+        assert counter == baseline_counter
+        assert all("nan" not in chunk_id.lower() for (_, _, chunk_id, _) in entries)
+
+
+@pytest.mark.parametrize(
+    "namespace_value",
+    [None, "", "   ", float("nan"), "vault"],
+)
+def test_default_namespace_applied(namespace_value):
+    df = pd.DataFrame(
+        [
+            {
+                "doc_id": "D",
+                "namespace": namespace_value,
+                "text": "x",
+                "embedding": [0.1, 0.2],
+            }
+        ]
+    )
+    batches = list(to_batches(df, default_namespace="vault-default"))
+    assert batches[0]["namespace"] == "vault-default"


### PR DESCRIPTION
## Summary
- restore deterministic chunk ID derivation with doc-specific prefixes, numeric normalization, and stable hash/row fallbacks
- extend the push_index unit suite with ordering regression coverage plus a Hypothesis-based property test
- document and expose testing workflows via optional `test` extras, new Makefile targets, CI bootstrapping for Hypothesis, and README coverage of integration test shortcuts
- stabilise Hypothesis-based tests with a reusable `ci` profile loaded via `tests/conftest.py` and enabled in CI

## Testing
- `uv run pytest -q -m "not integration"` *(fails: cannot download dependencies in the sandboxed environment)*

------
https://chatgpt.com/codex/tasks/task_e_68fdd3631f68832cb80a62d1ebde259a