### PR TITLE
Clarify embedding type in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,22 @@ Search (Embedding vorerst Pflicht)
 ```bash
 curl -sS localhost:8080/index/search \
   -H 'content-type: application/json' \
-  -d '{"query":"hello","k":5,"namespace":"vault","embedding":[0.1,0.2,0.3]}'
+  -d '{
+    "query":{
+      "text":"hello",
+      "meta":{
+        "embedding":[0.1,0.2,0.3]
+      }
+    },
+    "k":5,
+    "namespace":"vault"
+  }'
+
+# Legacy-Unterstützung:
+# Alternativ darf `embedding` auf Top-Level oder (rückwärtskompatibel)
+# im Top-Level `meta.embedding` stehen. Falls mehrere vorhanden sind, gewinnt
+# der Wert aus `query.meta.embedding`.
+# Embeddings werden als Liste von Floats (`f32`) erwartet.
 ```
 
 ### Persistenz (optional)

--- a/crates/indexd/src/api.rs
+++ b/crates/indexd/src/api.rs
@@ -32,7 +32,7 @@ pub struct DeleteRequest {
 #[derive(Debug, Deserialize)]
 pub struct SearchRequest {
     /// TODO(server-side-embeddings): replace client-provided vectors with generated embeddings.
-    pub query: String,
+    pub query: QueryPayload,
     #[serde(default = "default_k")]
     pub k: u32,
     pub namespace: String,
@@ -41,9 +41,30 @@ pub struct SearchRequest {
     /// Optional top-level embedding payload until server-side embeddings are available.
     #[serde(default)]
     pub embedding: Option<Value>,
-    /// Temporarily required until server-side embeddings are wired in.
-    #[serde(default = "default_meta")]
-    pub meta: Value,
+    /// Legacy fallback: support former top-level `meta.embedding`
+    /// (kept optional to remain backward compatible).
+    #[serde(default)]
+    pub meta: Option<Value>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(untagged)]
+pub enum QueryPayload {
+    Text(String),
+    WithMeta {
+        text: String,
+        #[serde(default = "default_meta")]
+        meta: Value,
+    },
+}
+
+impl QueryPayload {
+    fn text(&self) -> &str {
+        match self {
+            QueryPayload::Text(text) => text,
+            QueryPayload::WithMeta { text, .. } => text,
+        }
+    }
 }
 
 #[derive(Debug, Serialize)]
@@ -152,8 +173,10 @@ async fn handle_search(
     State(state): State<Arc<AppState>>,
     Json(payload): Json<SearchRequest>,
 ) -> Result<Json<SearchResponse>, (StatusCode, Json<Value>)> {
+    let query_text = payload.query.text();
+
     info!(
-        query = %payload.query,
+        query = %query_text,
         k = payload.k,
         namespace = %payload.namespace,
         filters = payload
@@ -165,36 +188,51 @@ async fn handle_search(
     );
 
     let SearchRequest {
+        query,
         k,
         namespace,
         filters,
-        meta,
         embedding,
-        ..
+        meta,
     } = payload;
 
-    let k = k as usize;
-
-    let embedding = if let Some(value) = embedding {
-        parse_embedding(value).map_err(bad_request)?
-    } else {
-        let mut meta = match meta {
-            Value::Object(map) => map,
-            _ => {
-                return Err(bad_request(
-                    "search meta must be an object containing an embedding array",
-                ))
-            }
-        };
-
-        let embedding_value = meta
-            .remove("embedding")
-            .ok_or_else(|| bad_request("search meta must contain an embedding array"))?;
-
-        parse_embedding(embedding_value).map_err(bad_request)?
+    let query_embedding_value = match query {
+        QueryPayload::Text(_) => None,
+        QueryPayload::WithMeta { meta, .. } => {
+            let mut meta_map = match meta {
+                Value::Object(map) => map,
+                _ => return Err(bad_request("query meta must be an object")),
+            };
+            meta_map.remove("embedding")
+        }
     };
 
+    let k = k as usize;
     let filter_value = filters.unwrap_or(Value::Null);
+
+    // Priority: query.meta.embedding > top-level embedding > legacy meta.embedding
+    let embedding: Vec<f32> = if let Some(value) = query_embedding_value {
+        parse_embedding(value).map_err(bad_request)?
+    } else if let Some(value) = embedding {
+        parse_embedding(value).map_err(bad_request)?
+    } else if let Some(meta) = meta {
+        let mut legacy_meta = match meta {
+            Value::Object(map) => map,
+            _ => return Err(bad_request("legacy meta must be an object")),
+        };
+
+        let Some(value) = legacy_meta.remove("embedding") else {
+            return Err(bad_request(
+                "embedding is required (provide query.meta.embedding, top-level embedding, or legacy meta.embedding)",
+            ));
+        };
+
+        parse_embedding(value).map_err(bad_request)?
+    } else {
+        return Err(bad_request(
+            "embedding is required (provide query.meta.embedding, top-level embedding, or legacy meta.embedding)",
+        ));
+    };
 
     let store = state.store.read().await;
     let scored = store.search(&namespace, &embedding, k, &filter_value);
@@ -284,12 +322,12 @@ mod tests {
     async fn search_requires_embedding() {
         let state = Arc::new(AppState::new());
         let payload = SearchRequest {
-            query: "hello".into(),
+            query: QueryPayload::Text("hello".into()),
             k: 5,
             namespace: "ns".into(),
             filters: None,
             embedding: None,
-            meta: Value::Null,
+            meta: None,
         };
 
         let result = handle_search(State(state), Json(payload)).await;
@@ -314,15 +352,78 @@ mod tests {
         assert!(upsert_result.is_ok(), "upsert should succeed");
 
         let payload = SearchRequest {
-            query: "hello".into(),
+            query: QueryPayload::Text("hello".into()),
             k: 1,
             namespace: "ns".into(),
             filters: None,
             embedding: Some(json!([0.1, 0.2])),
-            meta: Value::Null,
+            meta: None,
         };
 
         let result = handle_search(State(state), Json(payload)).await;
         assert!(result.is_ok(), "search should accept top-level embedding");
+    }
+
+    #[tokio::test]
+    async fn search_accepts_query_meta_embedding() {
+        let state = Arc::new(AppState::new());
+
+        let upsert_payload = UpsertRequest {
+            doc_id: "doc".into(),
+            namespace: "ns".into(),
+            chunks: vec![ChunkPayload {
+                id: "chunk-1".into(),
+                _text: "ignored".into(),
+                meta: json!({ "embedding": [0.1, 0.2] }),
+            }],
+        };
+
+        let upsert_result = handle_upsert(State(state.clone()), Json(upsert_payload)).await;
+        assert!(upsert_result.is_ok(), "upsert should succeed");
+
+        let payload = SearchRequest {
+            query: QueryPayload::WithMeta {
+                text: "hello".into(),
+                meta: json!({ "embedding": [0.1, 0.2] }),
+            },
+            k: 1,
+            namespace: "ns".into(),
+            filters: None,
+            embedding: None,
+            meta: None,
+        };
+
+        let result = handle_search(State(state), Json(payload)).await;
+        assert!(result.is_ok(), "search should accept query.meta.embedding");
+    }
+
+    #[tokio::test]
+    async fn search_accepts_legacy_meta_embedding() {
+        let state = Arc::new(AppState::new());
+
+        let upsert_payload = UpsertRequest {
+            doc_id: "doc".into(),
+            namespace: "ns".into(),
+            chunks: vec![ChunkPayload {
+                id: "chunk-1".into(),
+                _text: "ignored".into(),
+                meta: json!({ "embedding": [0.1, 0.2] }),
+            }],
+        };
+
+        let upsert_result = handle_upsert(State(state.clone()), Json(upsert_payload)).await;
+        assert!(upsert_result.is_ok(), "upsert should succeed");
+
+        let payload = SearchRequest {
+            query: QueryPayload::Text("hello".into()),
+            k: 1,
+            namespace: "ns".into(),
+            filters: None,
+            embedding: None,
+            meta: Some(json!({ "embedding": [0.1, 0.2] })),
+        };
+
+        let result = handle_search(State(state), Json(payload)).await;
+        assert!(result.is_ok(), "search should accept legacy meta.embedding");
     }
 }

--- a/crates/indexd/tests/search.rs
+++ b/crates/indexd/tests/search.rs
@@ -6,7 +6,7 @@ use serde_json::json;
 use tower::ServiceExt;
 
 #[tokio::test]
-async fn upsert_then_search_returns_hit() {
+async fn upsert_then_search_with_query_meta_embedding_returns_hit() {
     let state = Arc::new(AppState::new());
     let app = api::router(state.clone());
 
@@ -19,7 +19,6 @@ async fn upsert_then_search_returns_hit() {
             "meta": {"embedding": [1.0, 0.0], "snippet": "hello"}
         }]
     });
-
     let response = app
         .clone()
         .oneshot(
@@ -32,13 +31,191 @@ async fn upsert_then_search_returns_hit() {
         )
         .await
         .unwrap();
+    assert!(response.status().is_success());
 
+    let search_payload = json!({
+        "query": {
+            "text": "hello",
+            "meta": {"embedding": [1.0, 0.0]}
+        },
+        "k": 5,
+        "namespace": "ns"
+    });
+    let response = app
+        .oneshot(
+            Request::builder()
+                .uri("/index/search")
+                .method("POST")
+                .header("content-type", "application/json")
+                .body(Body::from(search_payload.to_string()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert!(response.status().is_success());
+
+    let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+    let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+
+    let results = json["results"]
+        .as_array()
+        .expect("results should be an array");
+    assert_eq!(results.len(), 1);
+    assert_eq!(results[0]["doc_id"], "d1");
+    assert_eq!(results[0]["chunk_id"], "c1");
+}
+
+#[tokio::test]
+async fn upsert_then_search_with_top_level_embedding_returns_hit() {
+    let state = Arc::new(AppState::new());
+    let app = api::router(state.clone());
+
+    let upsert_payload = json!({
+        "doc_id": "d1",
+        "namespace": "ns",
+        "chunks": [{
+            "id": "c1",
+            "text": "hello",
+            "meta": {"embedding": [1.0, 0.0], "snippet": "hello"}
+        }]
+    });
+    let response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .uri("/index/upsert")
+                .method("POST")
+                .header("content-type", "application/json")
+                .body(Body::from(upsert_payload.to_string()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
     assert!(response.status().is_success());
 
     let search_payload = json!({
         "query": "hello",
         "k": 5,
         "namespace": "ns",
+        "embedding": [1.0, 0.0]
+    });
+    let response = app
+        .oneshot(
+            Request::builder()
+                .uri("/index/search")
+                .method("POST")
+                .header("content-type", "application/json")
+                .body(Body::from(search_payload.to_string()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert!(response.status().is_success());
+
+    let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+    let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+
+    let results = json["results"]
+        .as_array()
+        .expect("results should be an array");
+    assert_eq!(results.len(), 1);
+    assert_eq!(results[0]["doc_id"], "d1");
+    assert_eq!(results[0]["chunk_id"], "c1");
+}
+
+#[tokio::test]
+async fn upsert_then_search_with_legacy_meta_embedding_returns_hit() {
+    let state = Arc::new(AppState::new());
+    let app = api::router(state.clone());
+
+    let upsert_payload = json!({
+        "doc_id": "d1",
+        "namespace": "ns",
+        "chunks": [{
+            "id": "c1",
+            "text": "hello",
+            "meta": {"embedding": [1.0, 0.0], "snippet": "hello"}
+        }]
+    });
+    let response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .uri("/index/upsert")
+                .method("POST")
+                .header("content-type", "application/json")
+                .body(Body::from(upsert_payload.to_string()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert!(response.status().is_success());
+
+    let search_payload = json!({
+        "query": "hello",
+        "k": 5,
+        "namespace": "ns",
+        "meta": {"embedding": [1.0, 0.0]}
+    });
+    let response = app
+        .oneshot(
+            Request::builder()
+                .uri("/index/search")
+                .method("POST")
+                .header("content-type", "application/json")
+                .body(Body::from(search_payload.to_string()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert!(response.status().is_success());
+
+    let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+    let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+
+    let results = json["results"]
+        .as_array()
+        .expect("results should be an array");
+    assert_eq!(results.len(), 1);
+    assert_eq!(results[0]["doc_id"], "d1");
+    assert_eq!(results[0]["chunk_id"], "c1");
+}
+
+#[tokio::test]
+async fn query_meta_embedding_overrides_other_locations() {
+    let state = Arc::new(AppState::new());
+    let app = api::router(state.clone());
+
+    let upsert_payload = json!({
+        "doc_id": "d1",
+        "namespace": "ns",
+        "chunks": [
+            {"id": "c1", "text": "x", "meta": {"embedding": [1.0, 0.0], "snippet": "x"}},
+            {"id": "c2", "text": "y", "meta": {"embedding": [0.0, 1.0], "snippet": "y"}}
+        ]
+    });
+    let response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .uri("/index/upsert")
+                .method("POST")
+                .header("content-type", "application/json")
+                .body(Body::from(upsert_payload.to_string()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert!(response.status().is_success());
+
+    let search_payload = json!({
+        "query": {
+            "text": "irrelevant",
+            "meta": {"embedding": [0.0, 1.0]}
+        },
+        "namespace": "ns",
+        "k": 1,
+        "embedding": [1.0, 0.0],
         "meta": {"embedding": [1.0, 0.0]}
     });
 
@@ -53,7 +230,6 @@ async fn upsert_then_search_returns_hit() {
         )
         .await
         .unwrap();
-
     assert!(response.status().is_success());
 
     let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
@@ -64,5 +240,5 @@ async fn upsert_then_search_returns_hit() {
         .expect("results should be an array");
     assert_eq!(results.len(), 1);
     assert_eq!(results[0]["doc_id"], "d1");
-    assert_eq!(results[0]["chunk_id"], "c1");
+    assert_eq!(results[0]["chunk_id"], "c2");
 }

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -20,6 +20,34 @@ cp examples/semantah.example.yml semantah.yml
 make all           # embeddings → index → graph → related
 cargo run -p indexd
 curl -fsS localhost:8080/healthz || true
+
+# Index-Stubs registrieren (Embeddings im Meta-Objekt)
+curl -sS localhost:8080/index/upsert \
+  -H 'content-type: application/json' \
+  -d '{
+    "doc_id": "demo-note",
+    "namespace": "vault",
+    "chunks": [{
+      "id": "demo-note#0",
+      "text": "Hello demo",
+      "meta": {
+        "embedding": [0.1, 0.2, 0.3],
+        "snippet": "Hello demo"
+      }
+    }]
+  }'
+
+# Smoke-Test: Suche mit query.meta.embedding (liefert ggf. leere Treffer)
+curl -sS localhost:8080/index/search \
+  -H 'content-type: application/json' \
+  -d '{
+    "query": {
+      "text": "hello",
+      "meta": { "embedding": [0.1, 0.2, 0.3] }
+    },
+    "namespace": "vault",
+    "k": 5
+  }'
 ```
 
 Weitere Details:

--- a/scripts/push_index.py
+++ b/scripts/push_index.py
@@ -74,12 +74,13 @@ def to_batches(df: pd.DataFrame, default_namespace: str) -> Iterable[Dict[str, A
 
     for record in records:
         doc_id = _derive_doc_id(record)
-        # Treat NaN/None/empty/whitespace namespaces as missing before defaulting
-        _ns_value = record.get("namespace")
-        if _is_missing(_ns_value):
-            namespace = str(default_namespace)
+        ns_value = record.get("namespace")
+        if _is_missing(ns_value):
+            namespace = default_namespace
         else:
-            namespace = str(_ns_value).strip() or str(default_namespace)
+            namespace = str(ns_value).strip()
+            if not namespace:
+                namespace = default_namespace
         key = (namespace, doc_id)
         batch = grouped.setdefault(
             key,
@@ -95,17 +96,19 @@ def to_batches(df: pd.DataFrame, default_namespace: str) -> Iterable[Dict[str, A
 
 
 def _derive_doc_id(record: Dict[str, Any]) -> str:
+    """Derive a stable document identifier from a record."""
+
     for key in ("doc_id", "path", "id"):
         value = record.get(key)
-        # Skip NaN/None/empty values reported by pandas before accepting
         if _is_missing(value):
             continue
-        if isinstance(value, str):
-            stripped = value.strip()
-            if stripped:
-                return stripped
+        if isinstance(value, (str, int)):
+            candidate = str(value).strip()
+            if candidate:
+                return candidate
             continue
-        return str(value)
+        if value is not None:
+            return str(value)
     raise ValueError("Record without doc identifier")
 
 


### PR DESCRIPTION
## Summary
- allow search requests to carry embeddings in `query.meta`, fall back to legacy locations, and add coverage
- document the embedding payload expectations across README, docs, and quickstart examples
- harden the index push script when deriving namespaces and document identifiers, trimming whitespace and empty fallbacks

## Testing
- cargo test -p indexd

------
https://chatgpt.com/codex/tasks/task_e_68fdc8ac3e50832c9afc89e481e135cb