### PR TITLE
Refine e2e HTTP test router construction

### DIFF
--- a/crates/indexd/tests/e2e_http.rs
+++ b/crates/indexd/tests/e2e_http.rs
@@ -2,7 +2,7 @@ use std::net::SocketAddr;
 use std::sync::Arc;
 
 use axum::Router;
-use indexd::{api, AppState};
+use indexd::{api, router as base_router, AppState};
 use serde_json::json;
 use tokio::net::TcpListener;
 
@@ -10,7 +10,9 @@ use tokio::net::TcpListener;
 async fn upsert_and_search_over_http() {
     // --- start server on a random local port
     let state = Arc::new(AppState::new());
-    let app: Router = api::router(state);
+    let app: Router = Router::new()
+        .merge(base_router(state.clone()))
+        .merge(api::router(state));
 
     let listener = TcpListener::bind(("127.0.0.1", 0)).await.unwrap();
     let addr: SocketAddr = listener.local_addr().unwrap();


### PR DESCRIPTION
## Summary
- construct the test HTTP app by merging the base and API routers into a fresh Router instance for clearer composition

## Testing
- cargo test -p indexd --test e2e_http *(fails: unable to download crates due to 403 when fetching crates.io index)*

------
https://chatgpt.com/codex/tasks/task_e_68ff90734e1c832c924bfde8ea9e9841