### PR TITLE
Avoid double-merging base router in index API

### DIFF
--- a/crates/indexd/src/api.rs
+++ b/crates/indexd/src/api.rs
@@ -82,13 +82,13 @@ pub struct SearchHit {
 }
 
 pub fn router(state: Arc<AppState>) -> Router {
-    let api_routes = Router::new()
+    // NOTE: Only API routes here. Base routes (e.g. /healthz) are merged in `indexd::run`
+    // (and in Tests explizit), um doppelte Registrierung zu vermeiden.
+    Router::new()
         .route("/index/upsert", post(handle_upsert))
         .route("/index/delete", post(handle_delete))
         .route("/index/search", post(handle_search))
-        .with_state(state.clone());
-
-    crate::router(state).merge(api_routes)
+        .with_state(state)
 }
 
 fn default_k() -> u32 {
@@ -308,10 +308,7 @@ mod tests {
     #[async_trait]
     impl Embedder for TestEmbedder {
         async fn embed(&self, texts: &[String]) -> anyhow::Result<Vec<Vec<f32>>> {
-            Ok(texts
-                .iter()
-                .map(|_| vec![1.0f32, 0.0])
-                .collect())
+            Ok(texts.iter().map(|_| vec![1.0f32, 0.0]).collect())
         }
 
         fn dim(&self) -> usize {


### PR DESCRIPTION
## Summary
- keep the index API router limited to API endpoints
- document that the base router is merged in `indexd::run`
- stop re-merging the base router inside the API router

## Testing
- cargo fmt

------
https://chatgpt.com/codex/tasks/task_e_690059b2d428832cac9b71956ffb7f5b