### PR TITLE
Ensure indexd upserts validate atomically and improve embedder errors

### DIFF
--- a/crates/embeddings/src/lib.rs
+++ b/crates/embeddings/src/lib.rs
@@ -120,11 +120,15 @@ impl Embedder for OllamaEmbedder {
             .send()
             .await?;
 
-        if !response.status().is_success() {
-            return Err(anyhow!(
-                "ollama responded with status {}",
-                response.status()
-            ));
+        let status = response.status();
+        if !status.is_success() {
+            let message = response.text().await.unwrap_or_default();
+            let detail = if message.trim().is_empty() {
+                String::new()
+            } else {
+                format!(": {}", message)
+            };
+            return Err(anyhow!("ollama responded with status {}{}", status, detail));
         }
 
         let body: OllamaResponse = response.json().await?;

--- a/docs/indexd-api.md
+++ b/docs/indexd-api.md
@@ -70,9 +70,14 @@ Lokale Entwicklungsumgebungen laufen ohne Authentifizierung. Für produktive Set
     ]
   }
   ```
-  **Kompatibilität:** Clients können das Feld `embedding` auf Top-Level senden;
-  legacy-Clients dürfen außerdem `meta.embedding` (Top-Level) verwenden.
-  Priorität: `query.meta.embedding` > `embedding` > `meta.embedding`.
+  **Kompatibilität & Priorität:** Es gibt mehrere Quellen für Embeddings.
+  Die Auswertungsreihenfolge ist **klar definiert** (erstes vorhandenes gewinnt):
+  1. `query.meta.embedding`
+  2. Top-Level `embedding`
+  3. Legacy Top-Level `meta.embedding`
+  4. **Serverseitig**: Falls oben nichts gesetzt und `INDEXD_EMBEDDER_PROVIDER` konfiguriert ist,
+     wird der Query-Text serverseitig eingebettet (z. B. via Ollama).
+
   Ein `embedding` ist eine Liste von Gleitkommazahlen (`f32`). Ist auf dem
   Server `INDEXD_EMBEDDER_PROVIDER=ollama` (plus optionale Parameter) gesetzt,
   wird – falls kein Embedding im Request vorliegt – der Query-Text über den


### PR DESCRIPTION
## Summary
- validate Ollama responses by checking the HTTP status and surfacing the response body when failures occur
- stage indexd upsert payloads before acquiring the write lock and guard against dimension changes prior to committing
- add clearer error context when loading or saving JSONL data (including directory creation) and document the search embedding precedence

## Testing
- cargo test -p indexd *(fails: unable to download crates index due to 403 CONNECT tunnel response)*

------
https://chatgpt.com/codex/tasks/task_e_6904600218a8832c9345a55ffaaaf905