### PR TITLE
feat(rust): Harden Rust core and clean up CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -189,7 +189,7 @@ jobs:
             uv-${{ runner.os }}-
 
       - name: Sync env
-        run: uv sync --frozen
+        run: uv sync --frozen --extra test
 
       - name: Ensure pyarrow available (CI bootstrap)
         run: |
@@ -205,18 +205,6 @@ jobs:
 
       - name: Prepare reports dir
         run: mkdir -p reports
-
-      - name: Ensure pytest-cov available (bootstrap-in-CI only)
-        run: |
-          uv run python - <<'PY'
-          import sys, subprocess
-          try:
-              import pytest_cov, coverage  # noqa: F401
-              print("pytest-cov & coverage already present")
-          except Exception:
-              print("Installing pytest-cov & coverage just for CI…")
-              subprocess.check_call([sys.executable, "-m", "pip", "install", "pytest-cov", "coverage"])
-          PY
 
       # --- Unit-Tests + JUnit + Coverage ---
       - name: Unit tests (exclude integration)
@@ -303,7 +291,7 @@ jobs:
             uv-${{ runner.os }}-
 
       - name: Sync env
-        run: uv sync --frozen
+        run: uv sync --frozen --extra test
 
       - name: Ensure pyarrow available (CI bootstrap)
         run: |
@@ -319,18 +307,6 @@ jobs:
 
       - name: Prepare reports dir
         run: mkdir -p reports
-
-      - name: Ensure pytest-cov available (bootstrap-in-CI only)
-        run: |
-          uv run python - <<'PY'
-          import sys, subprocess
-          try:
-              import pytest_cov, coverage  # noqa: F401
-              print("pytest-cov & coverage already present")
-          except Exception:
-              print("Installing pytest-cov & coverage just for CI…")
-              subprocess.check_call([sys.executable, "-m", "pip", "install", "pytest-cov", "coverage"])
-          PY
 
       # --- Integration-Tests + JUnit + Coverage ---
       - name: Integration tests
@@ -385,6 +361,19 @@ jobs:
         with:
           python-version: "3.11"
 
+      - name: uv cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cache/uv
+            .venv
+          key: uv-${{ runner.os }}-${{ hashFiles('**/pyproject.toml', '**/uv.lock') }}
+          restore-keys: |
+            uv-${{ runner.os }}-
+
+      - name: Sync env
+        run: uv sync --frozen --extra test
+
       - name: Prepare reports dir
         run: mkdir -p reports
 
@@ -399,18 +388,6 @@ jobs:
         with:
           name: coverage-integration
           path: reports
-
-      - name: Ensure coverage available
-        run: |
-          uv run python - <<'PY'
-          import sys, subprocess
-          try:
-              import coverage  # noqa: F401
-              print("coverage present")
-          except Exception:
-              print("Installing coverage just for CI…")
-              subprocess.check_call([sys.executable, "-m", "pip", "install", "coverage"])
-          PY
 
       - name: Combine .coverage files
         env:

--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,5 @@ semantah.yml
 .DS_Store
 Thumbs.db
 
+# Logs
+*.log

--- a/crates/indexd/Cargo.toml
+++ b/crates/indexd/Cargo.toml
@@ -26,3 +26,18 @@ tempfile = "3"
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
 async-trait = "0.1"
 
+[[test]]
+name = "healthz"
+path = "tests/healthz.rs"
+
+[[test]]
+name = "search"
+path = "tests/search.rs"
+
+[[test]]
+name = "e2e_http"
+path = "tests/e2e_http.rs"
+
+[[test]]
+name = "upsert"
+path = "tests/upsert.rs"

--- a/crates/indexd/src/api.rs
+++ b/crates/indexd/src/api.rs
@@ -160,6 +160,8 @@ async fn handle_upsert(
         }
     }
 
+    store.delete_doc(&namespace, &doc_id);
+
     for (id, vector, meta) in staged {
         store
             .upsert(&namespace, &doc_id, &id, vector, meta)

--- a/crates/indexd/tests/upsert.rs
+++ b/crates/indexd/tests/upsert.rs
@@ -1,0 +1,199 @@
+use std::sync::Arc;
+
+use axum::{body::to_bytes, body::Body, http::Request, http::StatusCode};
+use indexd::{api, AppState};
+use serde_json::json;
+use tower::ServiceExt;
+
+#[tokio::test]
+async fn upsert_with_dimension_mismatch_fails() {
+    let state = Arc::new(AppState::new());
+    let app = api::router(state.clone());
+
+    let upsert_payload1 = json!({
+        "doc_id": "d1",
+        "namespace": "ns",
+        "chunks": [{
+            "id": "c1",
+            "text": "hello",
+            "meta": {"embedding": [1.0, 0.0], "snippet": "hello"}
+        }]
+    });
+    let response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .uri("/index/upsert")
+                .method("POST")
+                .header("content-type", "application/json")
+                .body(Body::from(upsert_payload1.to_string()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert!(response.status().is_success());
+
+    let upsert_payload2 = json!({
+        "doc_id": "d2",
+        "namespace": "ns",
+        "chunks": [{
+            "id": "c2",
+            "text": "world",
+            "meta": {"embedding": [1.0, 0.0, 0.0], "snippet": "world"}
+        }]
+    });
+    let response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .uri("/index/upsert")
+                .method("POST")
+                .header("content-type", "application/json")
+                .body(Body::from(upsert_payload2.to_string()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+
+    let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+    let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    assert_eq!(
+        json["error"],
+        "chunk embedding dimensionality mismatch: expected 2, got 3"
+    );
+}
+
+#[tokio::test]
+async fn upsert_is_atomic_and_replaces_old_chunks() {
+    let state = Arc::new(AppState::new());
+    let app = api::router(state.clone());
+
+    let upsert_payload1 = json!({
+        "doc_id": "d1",
+        "namespace": "ns",
+        "chunks": [{
+            "id": "c1",
+            "text": "hello",
+            "meta": {"embedding": [1.0, 0.0], "snippet": "hello"}
+        }]
+    });
+    let response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .uri("/index/upsert")
+                .method("POST")
+                .header("content-type", "application/json")
+                .body(Body::from(upsert_payload1.to_string()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert!(response.status().is_success());
+
+    let search_payload1 = json!({
+        "query": {
+            "text": "hello",
+            "meta": {"embedding": [1.0, 0.0]}
+        },
+        "k": 5,
+        "namespace": "ns"
+    });
+    let response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .uri("/index/search")
+                .method("POST")
+                .header("content-type", "application/json")
+                .body(Body::from(search_payload1.to_string()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert!(response.status().is_success());
+    let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+    let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    let results = json["results"].as_array().unwrap();
+    assert_eq!(results.len(), 1);
+    assert_eq!(results[0]["chunk_id"], "c1");
+
+    let upsert_payload2 = json!({
+        "doc_id": "d1",
+        "namespace": "ns",
+        "chunks": [{
+            "id": "c2",
+            "text": "world",
+            "meta": {"embedding": [0.0, 1.0], "snippet": "world"}
+        }]
+    });
+    let response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .uri("/index/upsert")
+                .method("POST")
+                .header("content-type", "application/json")
+                .body(Body::from(upsert_payload2.to_string()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert!(response.status().is_success());
+
+    let search_payload2 = json!({
+        "query": {
+            "text": "world",
+            "meta": {"embedding": [0.0, 1.0]}
+        },
+        "k": 5,
+        "namespace": "ns"
+    });
+    let response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .uri("/index/search")
+                .method("POST")
+                .header("content-type", "application/json")
+                .body(Body::from(search_payload2.to_string()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert!(response.status().is_success());
+    let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+    let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    let results = json["results"].as_array().unwrap();
+    assert_eq!(results.len(), 1);
+    assert_eq!(results[0]["chunk_id"], "c2");
+
+    let search_payload3 = json!({
+        "query": {
+            "text": "hello",
+            "meta": {"embedding": [1.0, 0.0]}
+        },
+        "k": 5,
+        "namespace": "ns"
+    });
+    let response = app
+        .oneshot(
+            Request::builder()
+                .uri("/index/search")
+                .method("POST")
+                .header("content-type", "application/json")
+                .body(Body::from(search_payload3.to_string()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert!(response.status().is_success());
+    let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+    let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    let results = json["results"].as_array().unwrap();
+    assert!(
+        results.iter().all(|r| r["chunk_id"] != "c1"),
+        "old chunk c1 should not be present in search results"
+    );
+}


### PR DESCRIPTION
This change implements several improvements to the Rust core and the CI pipeline, based on the user's cleanup checklist.

- **Atomic Upserts:** The `indexd` upsert operation is now atomic. It deletes all existing chunks for a document ID before inserting new chunks, ensuring data consistency.
- **Improved Tests:** Added integration tests to verify the atomicity of upserts and to handle dimension mismatches in embeddings.
- **CI Cleanup:** The CI workflow for Python tests now uses optional dependencies (`uv sync --extra test`) instead of installing packages ad-hoc during the run.
- **Ignore Log Files:** Added `*.log` to `.gitignore` to prevent log files from being accidentally committed.