### PR TITLE
fix(ci): Use stable version for actions/checkout

### DIFF
--- a/.github/workflows/knowledge-extract-and-ingest.yml
+++ b/.github/workflows/knowledge-extract-and-ingest.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@8ade135a242bde00fd19c0e54fb3760beea110ee
+      - uses: actions/checkout@v4
       - uses: actions/setup-node@5e221d4786ffb21088b21dfc9c80efb16b52cd3b
       - name: Install ajv-cli
         run: npm i -g ajv-cli@5


### PR DESCRIPTION
The 'knowledge-extract-and-ingest' workflow was failing because it used a specific commit SHA for 'actions/checkout' that is no longer accessible.

This change updates the workflow to use the stable version tag '@v4' instead, ensuring the action can be downloaded reliably.