### PR TITLE
fix(ci): Use stable version tag for setup-node action

### DIFF
--- a/.github/workflows/knowledge-extract-and-ingest.yml
+++ b/.github/workflows/knowledge-extract-and-ingest.yml
@@ -16,7 +16,7 @@ jobs:
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-node@5e221d4786ffb21088b21dfc9c80efb16b52cd3b
+      - uses: actions/setup-node@v4
       - name: Install ajv-cli
         run: npm i -g ajv-cli@5
       - name: Extract knowledge graph (falls wgx vorhanden)


### PR DESCRIPTION
The knowledge-extract-and-ingest workflow was failing because the commit SHA used for `actions/setup-node` was no longer valid.

This change replaces the hardcoded SHA with the stable `@v4` version tag to ensure the action can always be found and to improve the long-term stability of the workflow.