### PR TITLE
fix(ci): update knowledge graph schema URL in workflow

### DIFF
--- a/.github/workflows/knowledge-extract-and-ingest.yml
+++ b/.github/workflows/knowledge-extract-and-ingest.yml
@@ -31,7 +31,7 @@ jobs:
           fi
       - name: Validate knowledge.graph.json
         run: |
-          curl -fsSL https://raw.githubusercontent.com/heimgewebe/metarepo/contracts-v1/contracts/knowledge.graph.schema.json -o /tmp/schema.json
+          curl -fsSL https://raw.githubusercontent.com/heimgewebe/metarepo/main/contracts/knowledge.graph.schema.json -o /tmp/schema.json
           ajv validate --spec=draft2020 --strict=true -s /tmp/schema.json -d knowledge.graph.json
       - name: Ingest (best-effort)
         shell: bash


### PR DESCRIPTION
The `knowledge-extract-and-ingest` workflow was failing because the URL for the `knowledge.graph.schema.json` file was pointing to a non-existent `contracts-v1` branch.

This commit updates the URL to point to the `main` branch, where the schema file is located.