### PR TITLE
feat: Add persistence/embedder tests and CI structure guard

### DIFF
--- a/.github/workflows/guard_structure.yml
+++ b/.github/workflows/guard_structure.yml
@@ -1,0 +1,22 @@
+name: Repo structure guard
+
+on:
+  pull_request:
+  push:
+    branches: ["main"]
+
+permissions: read-all
+
+jobs:
+  structure-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Fail on duplicated semantAH subtree
+        run: |
+          if [ -d "semantAH" ]; then
+            echo "::error ::Found top-level 'semantAH/' directory (duplicated project tree)."
+            echo "Please remove it (git rm -r semantAH/) and fix any references."
+            exit 1
+          fi
+          echo "OK: no duplicated semantAH/ subtree."

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -81,6 +81,7 @@ checksum = "edca88bc138befd0323b20752846e6587272d3b03b0343c8ea28a6f819e6e71f"
 dependencies = [
  "async-trait",
  "axum-core",
+ "axum-macros",
  "bytes",
  "futures-util",
  "http 1.3.1",
@@ -126,6 +127,17 @@ dependencies = [
  "tower-layer",
  "tower-service",
  "tracing",
+]
+
+[[package]]
+name = "axum-macros"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57d123550fa8d071b7255cb0cc04dc302baa6c8c4a79f55701552684d8399bce"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -338,6 +350,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-trait",
+ "axum",
  "reqwest 0.11.27",
  "serde",
  "serde_json",

--- a/crates/embeddings/Cargo.toml
+++ b/crates/embeddings/Cargo.toml
@@ -14,4 +14,5 @@ serde_json.workspace = true
 tracing.workspace = true
 
 [dev-dependencies]
-tokio.workspace = true
+axum = { version = "0.7", default-features = false, features = ["macros", "json", "tokio", "http1"] }
+tokio = { workspace = true, features = ["rt-multi-thread", "macros", "net"] }

--- a/crates/embeddings/tests/ollama_error.rs
+++ b/crates/embeddings/tests/ollama_error.rs
@@ -1,0 +1,31 @@
+use axum::{routing::post, Router};
+use axum::http::StatusCode;
+use tokio::net::TcpListener;
+use embeddings::{OllamaEmbedder, OllamaConfig, Embedder};
+
+#[tokio::test]
+async fn ollama_embedder_returns_error_on_http_500() {
+    // Mini-Axum-Server, der /api/embeddings immer 500 liefert
+    async fn handler() -> (StatusCode, &'static str) {
+        (StatusCode::INTERNAL_SERVER_ERROR, "boom")
+    }
+    let app = Router::new().route("/api/embeddings", post(handler));
+
+    let listener = TcpListener::bind(("127.0.0.1", 0)).await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let _server = tokio::spawn(async move {
+        axum::serve(listener, app).await.unwrap();
+    });
+
+    let base = format!("http://{}", addr);
+    let embedder = OllamaEmbedder::new(OllamaConfig {
+        base_url: base,
+        model: "test-model".into(),
+        dim: 2,
+    });
+
+    let res = embedder.embed(&[String::from("hello")]).await;
+    assert!(res.is_err(), "expected error on HTTP 500");
+    let msg = format!("{:?}", res.err().unwrap());
+    assert!(msg.contains("status 500"), "error should mention status 500, got: {msg}");
+}

--- a/crates/indexd/src/lib.rs
+++ b/crates/indexd/src/lib.rs
@@ -1,6 +1,6 @@
 pub mod api;
 mod key;
-mod persist;
+pub mod persist;
 pub mod store;
 
 use std::{env, net::SocketAddr, sync::Arc};

--- a/crates/indexd/tests/persist_e2e.rs
+++ b/crates/indexd/tests/persist_e2e.rs
@@ -1,0 +1,72 @@
+use std::env;
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use indexd::{persist, AppState};
+use tempfile::tempdir;
+
+/// End-to-end Persistenztest ohne HTTP:
+/// 1) State A: upsert -> save (JSONL)
+/// 2) State B: load -> verifiziere Inhalte
+#[tokio::test]
+async fn vector_store_persist_and_load_roundtrip() {
+    // --- Temp-Datei für JSONL vorbereiten
+    let dir = tempdir().expect("tempdir");
+    let db_path: PathBuf = dir.path().join("store.jsonl");
+    env::set_var("INDEXD_DB_PATH", &db_path);
+
+    // --- State A: befüllen und speichern
+    let state_a = Arc::new(AppState::new());
+    {
+        let mut store = state_a.store.write().await;
+        // zwei Chunks, gleiche Dimensionalität
+        store
+            .upsert(
+                "ns",
+                "doc-1",
+                "c1",
+                vec![1.0f32, 0.0],
+                serde_json::json!({"snippet": "hello"}),
+            )
+            .expect("upsert c1");
+        store
+            .upsert(
+                "ns",
+                "doc-1",
+                "c2",
+                vec![0.5f32, 0.5],
+                serde_json::json!({"snippet": "world"}),
+            )
+            .expect("upsert c2");
+    }
+    // Save nach JSONL
+    persist::maybe_save_from_env(&state_a)
+        .await
+        .expect("save must succeed");
+    assert!(db_path.exists(), "persisted file must exist");
+
+    // --- State B: neu und leer, dann load
+    let state_b = Arc::new(AppState::new());
+    persist::maybe_load_from_env(&state_b)
+        .await
+        .expect("load must succeed");
+
+    // Verifikation
+    let store_b = state_b.store.read().await;
+
+    // Dimensionalität erhalten
+    assert_eq!(store_b.dims, Some(2));
+
+    // Zwei Items (ns/doc-1#{c1,c2})
+    assert_eq!(store_b.items.len(), 2, "must have exactly two items");
+
+    // Metadatenprüfung: snippet
+    let meta_c1 = store_b
+        .chunk_meta("ns", "doc-1", "c1")
+        .expect("meta for c1 must exist");
+    assert_eq!(meta_c1.get("snippet").and_then(|v| v.as_str()), Some("hello"));
+    let meta_c2 = store_b
+        .chunk_meta("ns", "doc-1", "c2")
+        .expect("meta for c2 must exist");
+    assert_eq!(meta_c2.get("snippet").and_then(|v| v.as_str()), Some("world"));
+}


### PR DESCRIPTION
- Adds an end-to-end test for `indexd` persistence to verify the save/load roundtrip.
- Adds an error-handling test for the Ollama embedder client to ensure it correctly handles HTTP 500 responses.
- Adds a new GitHub Actions workflow to prevent a duplicated `semantAH/` subdirectory from being committed.