### PR TITLE
feat(embeddings): add e2e tests for OllamaEmbedder

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -81,7 +81,6 @@ checksum = "edca88bc138befd0323b20752846e6587272d3b03b0343c8ea28a6f819e6e71f"
 dependencies = [
  "async-trait",
  "axum-core",
- "axum-macros",
  "bytes",
  "futures-util",
  "http 1.3.1",
@@ -127,17 +126,6 @@ dependencies = [
  "tower-layer",
  "tower-service",
  "tracing",
-]
-
-[[package]]
-name = "axum-macros"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57d123550fa8d071b7255cb0cc04dc302baa6c8c4a79f55701552684d8399bce"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]
@@ -351,6 +339,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "axum",
+ "hyper 1.7.0",
  "reqwest 0.11.27",
  "serde",
  "serde_json",

--- a/crates/embeddings/Cargo.toml
+++ b/crates/embeddings/Cargo.toml
@@ -14,5 +14,8 @@ serde_json.workspace = true
 tracing.workspace = true
 
 [dev-dependencies]
-axum = { version = "0.7", default-features = false, features = ["macros", "json", "tokio", "http1"] }
-tokio = { workspace = true, features = ["rt-multi-thread", "macros", "net"] }
+axum = "0.7"
+anyhow = "1"
+hyper = { version = "1", features = ["server"] }
+serde_json = "1"
+tokio = { version = "1", features = ["rt-multi-thread", "macros"] }

--- a/crates/embeddings/tests/ollama_mock.rs
+++ b/crates/embeddings/tests/ollama_mock.rs
@@ -1,0 +1,163 @@
+use std::net::SocketAddr;
+
+use anyhow::Result;
+use axum::{http::StatusCode, routing::post, Json, Router};
+use serde_json::json;
+use tokio::net::TcpListener;
+
+use embeddings::{Embedder, OllamaConfig, OllamaEmbedder};
+
+/// Minimaler Mock für /api/embeddings:
+/// Ignoriert den Request-Body und liefert für jede Eingabe
+/// einen Vektor der Länge 2 zurück.
+async fn mock_embeddings(Json(_body): Json<serde_json::Value>) -> Json<serde_json::Value> {
+    // Rückgabe-Form im Mehrfachfall: "embeddings": [[...], [...]]
+    // Wir geben zwei Vektoren zurück, um Mehrfacheingaben zu testen.
+    Json(json!({
+        "embeddings": [
+            { "embedding": [1.0, 0.0] },
+            { "embedding": [0.0, 1.0] }
+        ]
+    }))
+}
+
+/// Minimaler Mock für eine Einzeleingabe.
+async fn mock_single_embedding(Json(_body): Json<serde_json::Value>) -> Json<serde_json::Value> {
+    Json(json!({
+        "embeddings": [
+            { "embedding": [1.0, 0.0] }
+        ]
+    }))
+}
+
+/// Liefert absichtlich 500 mit einer kleinen Fehlermeldung.
+async fn mock_500(_body: String) -> (StatusCode, String) {
+    (StatusCode::INTERNAL_SERVER_ERROR, "boom".to_string())
+}
+
+/// Liefert eine falsche Dimensionalität (3), während der Embedder 2 erwartet.
+async fn mock_bad_dim(Json(_body): Json<serde_json::Value>) -> Json<serde_json::Value> {
+    Json(json!({
+        "embeddings": [
+            { "embedding": [1.0, 0.0, 0.5] }
+        ]
+    }))
+}
+
+#[tokio::test]
+async fn ollama_embedder_happy_path_against_mock() -> Result<()> {
+    // --- Mock-Server auf zufälligem Port hochfahren
+    let app = Router::new().route("/api/embeddings", post(mock_embeddings));
+    let listener = TcpListener::bind(("127.0.0.1", 0)).await?;
+    let addr: SocketAddr = listener.local_addr()?;
+    let server = tokio::spawn(async move {
+        axum::serve(listener, app).await.unwrap();
+    });
+
+    // --- Embedder auf Mock zeigen
+    let base = format!("http://{}", addr);
+    let embedder = OllamaEmbedder::new(OllamaConfig {
+        base_url: base,
+        model: "mock-embed".to_string(),
+        dim: 2,
+    });
+
+    // --- Zwei Texte => zwei Vektoren
+    let inputs = vec!["eins".to_string(), "zwei".to_string()];
+    let embeddings = embedder.embed(&inputs).await?;
+
+    // --- Assertions
+    assert_eq!(embeddings.len(), 2, "expected two embedding rows");
+    assert!(embeddings.iter().all(|v| v.len() == 2), "each vector must have dim=2");
+
+    // Inhalt grob prüfen (entspricht Mock)
+    assert_eq!(embeddings[0], vec![1.0, 0.0]);
+    assert_eq!(embeddings[1], vec![0.0, 1.0]);
+
+    // Server stoppen
+    server.abort();
+    Ok(())
+}
+
+/// Negativtest: Server liefert 500 → Embedder muss mit Status-Fehler (inkl. Body) abbrechen.
+#[tokio::test]
+async fn ollama_embedder_propagates_http_status_error() -> Result<()> {
+    // Mock, der 500 zurückgibt
+    let app = Router::new().route("/api/embeddings", post(mock_500));
+    let listener = TcpListener::bind(("127.0.0.1", 0)).await?;
+    let addr: SocketAddr = listener.local_addr()?;
+    let server = tokio::spawn(async move {
+        axum::serve(listener, app).await.unwrap();
+    });
+
+    let base = format!("http://{}", addr);
+    let embedder = OllamaEmbedder::new(OllamaConfig {
+        base_url: base,
+        model: "mock-embed".to_string(),
+        dim: 2,
+    });
+
+    let err = embedder.embed(&["x".to_string()]).await.unwrap_err();
+    let msg = err.to_string();
+    assert!(msg.contains("status 500"), "error should mention status 500, got: {msg}");
+    assert!(msg.contains("boom"), "error should include server message body, got: {msg}");
+
+    server.abort();
+    Ok(())
+}
+
+/// Negativtest: Falsche Dimensionalität (Server liefert 3, Embedder erwartet 2).
+#[tokio::test]
+async fn ollama_embedder_rejects_wrong_dimensions() -> Result<()> {
+    let app = Router::new().route("/api/embeddings", post(mock_bad_dim));
+    let listener = TcpListener::bind(("127.0.0.1", 0)).await?;
+    let addr: SocketAddr = listener.local_addr()?;
+    let server = tokio::spawn(async move {
+        axum::serve(listener, app).await.unwrap();
+    });
+
+    let base = format!("http://{}", addr);
+    let embedder = OllamaEmbedder::new(OllamaConfig {
+        base_url: base,
+        model: "mock-embed".to_string(),
+        dim: 2, // Erwartet 2
+    });
+
+    let err = embedder.embed(&["x".to_string()]).await.unwrap_err();
+    let msg = err.to_string();
+    assert!(
+        msg.contains("unexpected embedding dimensionality"),
+        "dimension validation should fail, got: {msg}"
+    );
+
+    server.abort();
+    Ok(())
+}
+
+/// Optional: Test für Einzeleingabe — Mock liefert trotzdem "embeddings" (Mehrfachform).
+#[tokio::test]
+async fn ollama_embedder_single_input_against_mock() -> Result<()> {
+    let app = Router::new().route("/api/embeddings", post(mock_single_embedding));
+    let listener = TcpListener::bind(("127.0.0.1", 0)).await?;
+    let addr: SocketAddr = listener.local_addr()?;
+    let server = tokio::spawn(async move {
+        axum::serve(listener, app).await.unwrap();
+    });
+
+    let base = format!("http://{}", addr);
+    let embedder = OllamaEmbedder::new(OllamaConfig {
+        base_url: base,
+        model: "mock-embed".to_string(),
+        dim: 2,
+    });
+
+    let inputs = vec!["solo".to_string()];
+    let embeddings = embedder.embed(&inputs).await?;
+
+    assert_eq!(embeddings.len(), 1, "must return one vector");
+    assert_eq!(embeddings[0].len(), 2, "dim must be 2");
+    assert_eq!(embeddings[0], vec![1.0, 0.0]);
+
+    server.abort();
+    Ok(())
+}


### PR DESCRIPTION
Adds a suite of end-to-end tests for the `OllamaEmbedder` using a mock server.

The tests cover:
- Happy path with single and multiple inputs
- Server returning a 500 error
- Server returning an embedding with a dimension mismatch