### PR TITLE
feat(embeddings): restore tokio net feature for tests

### DIFF
--- a/crates/embeddings/Cargo.toml
+++ b/crates/embeddings/Cargo.toml
@@ -18,4 +18,4 @@ axum = "0.7"
 anyhow = "1"
 hyper = { version = "1", features = ["server"] }
 serde_json = "1"
-tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
+tokio = { version = "1", features = ["rt-multi-thread", "macros", "net"] }


### PR DESCRIPTION
Restores the `net` feature for the `tokio` dev-dependency. This is required for the integration tests, which use `tokio::net::TcpListener` to create mock servers.