### PR TITLE
chore: update pr-heimgewebe-commands workflow to remove PAT dependency

### DIFF
--- a/.github/workflows/pr-heimgewebe-commands.yml
+++ b/.github/workflows/pr-heimgewebe-commands.yml
@@ -1,0 +1,16 @@
+---
+name: PR Heimgewebe commands
+
+"on":
+  issue_comment:
+    types: [created]
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+
+jobs:
+  dispatch:
+    if: github.event.issue.pull_request != null
+    uses: heimgewebe/metarepo/.github/workflows/heimgewebe-command-dispatch.yml@main


### PR DESCRIPTION
- Create `.github/workflows/pr-heimgewebe-commands.yml` which was missing.
- Use the PAT-free configuration (dispatching to reusable workflow without passing secrets).