### PR TITLE
Fix: NaN-safe vector search and improved Python error observability

### DIFF
--- a/cli/ingest_chronik.py
+++ b/cli/ingest_chronik.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import argparse
 import json
 import sys
+import traceback
 from collections import deque
 from dataclasses import dataclass
 from datetime import datetime, timezone
@@ -180,6 +181,8 @@ def main(argv: list[str] | None = None) -> int:
         output_path = ingest(args)
     except Exception as exc:  # pragma: no cover - small CLI
         print(f"Error: {exc}", file=sys.stderr)
+        # Preserve full traceback for debugging unexpected failures
+        traceback.print_exc()
         return 1
 
     print(output_path)

--- a/cli/ingest_intents.py
+++ b/cli/ingest_intents.py
@@ -5,6 +5,7 @@ import argparse
 import hashlib
 import json
 import sys
+import traceback
 from pathlib import Path
 from typing import Any, Dict, List
 
@@ -132,6 +133,7 @@ def main(argv: list[str] | None = None) -> int:
         return 1
     except Exception as e:
         print(f"Unexpected error: {e}", file=sys.stderr)
+        traceback.print_exc()
         return 1
 
 

--- a/scripts/push_index.py
+++ b/scripts/push_index.py
@@ -8,6 +8,7 @@ import hashlib
 import json
 import math
 import sys
+import traceback
 from pathlib import Path
 from typing import Any, Dict, Iterable, List, Set
 from urllib import error, request
@@ -277,6 +278,8 @@ def main() -> int:
         return 1
     except Exception as exc:
         print(f"[push-index] Unerwarteter Fehler: {exc}", file=sys.stderr)
+        # Preserve traceback for post-mortem analysis
+        traceback.print_exc()
         return 1
 
     if df.empty:


### PR DESCRIPTION
- crates/indexd: Filter NaN scores in vector search to prevent undefined sorting behavior.
- cli/*.py, scripts/push_index.py: Print full stack traces for unexpected exceptions.