### PR TITLE
fix: align default embedder dim and improve ingest robustness

### DIFF
--- a/cli/ingest_intents.py
+++ b/cli/ingest_intents.py
@@ -95,6 +95,10 @@ def ingest_intents(source_path: Path, nodes_path: Path, edges_path: Path):
                         nodes_file.write(json.dumps(element) + "\n")
             except json.JSONDecodeError:
                 print(f"Warning: Could not decode JSON: {line}", file=sys.stderr)
+            except Exception as e:
+                print(f"Warning: Failed to process record: {e}", file=sys.stderr)
+                # We do not print full traceback here to avoid log spam on bulk ingest,
+                # but we continue to the next record.
 
 
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:

--- a/crates/indexd/src/lib.rs
+++ b/crates/indexd/src/lib.rs
@@ -131,7 +131,7 @@ fn maybe_init_embedder() -> anyhow::Result<Option<Arc<dyn Embedder>>> {
                                 anyhow::anyhow!("INDEXD_EMBEDDER_DIM must be a positive integer, got: {}", value)
                             })?
                         }
-                        Err(_) => 1536, // Default dimension
+                        Err(_) => 768, // Default dimension (matches nomic-embed-text)
                     };
                     
                     if dim == 0 {


### PR DESCRIPTION
- Changed default `INDEXD_EMBEDDER_DIM` from 1536 to 768 in `crates/indexd/src/lib.rs` to match the default model `nomic-embed-text`.
- Updated `cli/ingest_intents.py` to robustly handle exceptions during record processing, preventing crashes on individual malformed records.