### PR TITLE
Ensure ingest_intents creates output directories

### DIFF
--- a/cli/ingest_intents.py
+++ b/cli/ingest_intents.py
@@ -76,6 +76,9 @@ def process_intent_record(record: Dict[str, Any]) -> List[Dict[str, Any]]:
 
 def ingest_intents(source_path: Path, nodes_path: Path, edges_path: Path):
     """Ingest intents from the source file and append to nodes and edges files."""
+    nodes_path.parent.mkdir(parents=True, exist_ok=True)
+    edges_path.parent.mkdir(parents=True, exist_ok=True)
+
     with (
         source_path.open("r", encoding="utf-8") as handle,
         nodes_path.open("a", encoding="utf-8") as nodes_file,

--- a/tests/test_ingest_intents.py
+++ b/tests/test_ingest_intents.py
@@ -86,3 +86,18 @@ def test_main_with_invalid_path():
         source_path = Path(temp_dir) / "non_existent.jsonl"
         argv = [str(source_path)]
         assert main(argv) == 1
+
+
+def test_ingest_intents_creates_output_dirs(intent_data, tmp_path):
+    source_path = tmp_path / "intents.jsonl"
+    nodes_path = tmp_path / ".gewebe" / "nodes.jsonl"
+    edges_path = tmp_path / ".gewebe" / "edges.jsonl"
+
+    with source_path.open("w", encoding="utf-8") as f:
+        for record in intent_data:
+            f.write(json.dumps(record) + "\n")
+
+    ingest_intents(source_path, nodes_path, edges_path)
+
+    assert nodes_path.is_file()
+    assert edges_path.is_file()


### PR DESCRIPTION
## Summary
- ensure ingest_intents creates parent directories for nodes and edges outputs before writing
- add regression coverage that default output paths are created automatically

## Testing
- pytest tests/test_ingest_intents.py


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6937f63211a8832ca56105078f50ced4)