### PR TITLE
Handle optional pandas and NA values

### DIFF
--- a/tests/test_push_index.py
+++ b/tests/test_push_index.py
@@ -115,6 +115,12 @@ def test_is_missing_covers_nan_none_and_whitespace():
     assert _is_missing("x") is False
 
 
+def test_is_missing_handles_pandas_and_numpy_na_types():
+    np = pytest.importorskip("numpy")
+    assert _is_missing(pd.NA) is True
+    assert _is_missing(np.nan) is True
+
+
 def test_to_batches_end_to_end_no_nan_ids_and_namespace_default():
     df = pd.DataFrame(
         [


### PR DESCRIPTION
## Summary
- load the pandas stub relative to push_index.py so the CLI works outside the repository root
- treat pandas/NumPy NA-style values as missing when deriving IDs in push_index
- add coverage for NA handling in the push_index tests

## Testing
- pytest -q


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69391d4f5fe8832c8b8be5b1ebd87f09)