### PR TITLE
Handle pandas Timestamp guard in push_index

### DIFF
--- a/scripts/push_index.py
+++ b/scripts/push_index.py
@@ -263,7 +263,11 @@ def _normalise_meta_value(value: Any) -> Any:
         return str(value)
     if hasattr(value, "tolist"):
         return value.tolist()  # type: ignore[no-any-return]
-    if isinstance(value, (pd.Timestamp,)):
+    # Some environments use the lightweight pandas stub, which does not expose
+    # a `Timestamp` type. Guard the isinstance check to avoid AttributeError
+    # when pandas is missing.
+    pd_timestamp = getattr(pd, "Timestamp", None)
+    if pd_timestamp is not None and isinstance(value, pd_timestamp):
         return value.isoformat()
     if hasattr(value, "item"):
         try:

--- a/tests/test_push_index.py
+++ b/tests/test_push_index.py
@@ -3,6 +3,8 @@ from itertools import permutations
 import pandas as pd
 import pytest
 
+import scripts.push_index
+
 from scripts.push_index import (
     _derive_chunk_id,
     _derive_doc_id,
@@ -119,6 +121,19 @@ def test_is_missing_handles_pandas_and_numpy_na_types():
     np = pytest.importorskip("numpy")
     assert _is_missing(pd.NA) is True
     assert _is_missing(np.nan) is True
+
+
+def test_normalise_meta_value_handles_stub_pandas(monkeypatch):
+    """_normalise_meta_value sollte ohne echte pandas.Timestamp laufen."""
+
+    class DummyPandas:
+        pass
+
+    monkeypatch.setattr(scripts.push_index, "pd", DummyPandas())
+
+    value = "2024-01-01"
+    # Should simply return the value without raising AttributeError
+    assert scripts.push_index._normalise_meta_value(value) == value
 
 
 def test_to_batches_end_to_end_no_nan_ids_and_namespace_default():


### PR DESCRIPTION
## Summary
- guard `_normalise_meta_value` against missing pandas Timestamp when running with the bundled stub
- add regression test to ensure the helper works without pandas installed

## Testing
- pytest -q

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693c84162c00832c83d3381c45778f39)