### PR TITLE
Handle invalid limits when reading chronik records

### DIFF
--- a/cli/ingest_chronik.py
+++ b/cli/ingest_chronik.py
@@ -69,6 +69,11 @@ def _coerce_tags(value) -> List[str]:
 
 
 def read_last_records(path: Path, limit: int) -> list[dict]:
+    if limit < 0:
+        raise ValueError("limit must be non-negative")
+    if limit == 0:
+        return []
+
     lines = deque(maxlen=limit)
     with path.open("r", encoding="utf-8") as handle:
         for raw_line in handle:

--- a/tests/test_ingest_chronik.py
+++ b/tests/test_ingest_chronik.py
@@ -1,0 +1,22 @@
+import json
+from pathlib import Path
+
+import pytest
+
+from cli import ingest_chronik
+
+
+def test_read_last_records_rejects_negative_limit(tmp_path: Path):
+    source = tmp_path / "chronik.jsonl"
+    source.write_text("{}\n", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="limit must be non-negative"):
+        ingest_chronik.read_last_records(source, -1)
+
+
+def test_read_last_records_zero_limit_returns_empty(tmp_path: Path):
+    source = tmp_path / "chronik.jsonl"
+    records = [{"title": "t", "summary": "s", "url": "u"}]
+    source.write_text("\n".join(json.dumps(r) for r in records), encoding="utf-8")
+
+    assert ingest_chronik.read_last_records(source, 0) == []


### PR DESCRIPTION
## Summary
- guard chronik ingestion against non-positive limits by returning early or raising a clear error
- add tests to verify negative and zero limit handling for `read_last_records`

## Testing
- pytest -q

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693d3828e678832caaaec8deead0243f)