### PR TITLE
Add scripts/observatory-mvp wrapper script

### DIFF
--- a/scripts/observatory-mvp
+++ b/scripts/observatory-mvp
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Minimal wrapper so humans and bots can run the MVP without guessing.
+# Writes: data/observatory/obs-<timestamp>.json
+
+python3 scripts/observatory_mvp.py


### PR DESCRIPTION
This commit adds a bash wrapper script `scripts/observatory-mvp` to invoke the Python script `scripts/observatory_mvp.py`. This aligns with the requested patch to provide a standard entry point for humans and bots.