### PR TITLE
fix(ci): allow x-producers/x-consumers custom keywords in AJV strict …

### DIFF
--- a/.github/workflows/publish-knowledge-observatory.yml
+++ b/.github/workflows/publish-knowledge-observatory.yml
@@ -58,6 +58,8 @@ jobs:
 
           echo "Validation Strictness: $STRICT"
 
+          # NOTE: Contract uses x-* metadata (x-producers/x-consumers).
+          # AJV strict rejects unknown keywords, so we disable strict mode here.
           npx --yes ajv-cli@5 validate --spec=draft2020 \
             --strict=false \
             -s contracts/knowledge.observatory.schema.json \


### PR DESCRIPTION
…validation

These fields are intentional contract-level metadata. Validation must accept them instead of rejecting valid schemas.