### PR TITLE
feat: add optional Plexer notification to observatory publish workflow

### DIFF
--- a/.github/workflows/publish-knowledge-observatory.yml
+++ b/.github/workflows/publish-knowledge-observatory.yml
@@ -123,7 +123,7 @@ jobs:
 
           echo "::notice::Notifying Plexer: ts=${TS}, generated_at=${GEN_AT}, url=${URL}"
 
-          PAYLOAD="$(cat <<EOF
+          cat > event.json <<EOF
           {
             "type": "knowledge.observatory.published.v1",
             "source": "semantAH",
@@ -134,11 +134,10 @@ jobs:
             }
           }
           EOF
-          )"
 
           curl -X POST "${PLEXER_URL%/}/events" \
             -H "Content-Type: application/json" \
             -H "Authorization: Bearer ${PLEXER_TOKEN}" \
-            -d "${PAYLOAD}" \
+            -d @event.json \
             --fail-with-body \
             || echo "::notice::Failed to notify plexer, but release succeeded."


### PR DESCRIPTION
- Add `Notify Plexer (knowledge.observatory)` step to `.github/workflows/publish-knowledge-observatory.yml`.
- Send `knowledge.observatory.published.v1` event with pointer payload (`ts`, `url`, `generated_at`).
- Ensure robust fail-open behavior (`continue-on-error`, secret check) to avoid breaking the supply chain.
- Use Python for robust `generated_at` extraction with fallback.