### PR TITLE
RPU-V1-T013: add RepoBrief chunk embedding bridge

### DIFF
--- a/docs/proofs/rpu-v1-t013-repobrief-chunk-bridge-proof.md
+++ b/docs/proofs/rpu-v1-t013-repobrief-chunk-bridge-proof.md
@@ -12,26 +12,41 @@ Patch SHA256: bind externally to current PR diff before merge
 | --- | --- |
 | Stable inputs | `scripts/repobrief_chunk_bridge.py` requires stable chunk id/id, byte range and content hash or derives content hash from text. Tests reject rows without stable range. |
 | External layer | Report marks owner `semantAH`, `repo_brief_core_ranking_changed: false`, `default_use: false`, and does not touch Lenskit/RepoBrief core. |
-| Evaluation before default use | Optional goldset path reports recall, MRR and miss taxonomy; default report status is `not_run` with `promotion_allowed: false`. |
+| Evaluation before default use | Goldset evaluation reports recall, MRR and miss taxonomy. `--baseline-report` compares those metrics against existing RepoBrief retrieval-eval metrics. Missing or regressed baseline comparison keeps `promotion_allowed: false`. |
 
 ## Validation
 
 ```bash
 python -m pytest tests/test_repobrief_chunk_bridge.py tests/test_push_index.py -q
 python -m ruff check scripts/repobrief_chunk_bridge.py tests/test_repobrief_chunk_bridge.py
+python -m py_compile scripts/repobrief_chunk_bridge.py tests/test_repobrief_chunk_bridge.py
 git diff --check
 ```
 
-Observed local result:
+Observed local result before the latest self-review hardening:
 
 - `17 passed, 1 skipped` (`numpy` missing for one pre-existing optional `push_index` test path)
 - Ruff passed
 - Diff whitespace check passed
 
+Latest hardening added:
+
+- query-aware deterministic goldset ranking for bridge evaluation;
+- explicit `--baseline-report` ingestion;
+- recall/MRR/miss-count regression comparison;
+- tests that keep `promotion_allowed` false even when the comparison passes.
+
 ## Self-review
 
-No blocker found in this bounded prototype. The main limitation is intentional: the default local embedding is a deterministic stand-in for bridge and evaluation mechanics. It is not evidence that semantic quality improves.
+Initial self-review found one gap: optional MRR was derived from JSONL input order
+and there was no explicit comparison against an existing RepoBrief retrieval
+baseline. The hardening closes that gap at the bridge-report level.
+
+Remaining limitation: the default local embedding is a deterministic stand-in for
+bridge and evaluation mechanics. It is not evidence that semantic quality improves.
 
 ## Non-claims
 
-This proof does not establish answer correctness, semantic correctness, runtime deployment, default-ranking improvement, RepoBrief-core promotion readiness, security correctness, full CI success, or absence of regressions.
+This proof does not establish answer correctness, semantic correctness, runtime
+deployment, default-ranking improvement, RepoBrief-core promotion readiness,
+security correctness, full CI success, or absence of regressions.

--- a/docs/proofs/rpu-v1-t013-repobrief-chunk-bridge-proof.md
+++ b/docs/proofs/rpu-v1-t013-repobrief-chunk-bridge-proof.md
@@ -1,0 +1,37 @@
+# RPU-V1-T013 RepoBrief chunk embedding bridge proof
+
+Status: review_ready
+Task: `RPU-V1-T013`
+PR: `heimgewebe/semantAH#254`
+Head: bind externally to current PR head before merge
+Patch SHA256: bind externally to current PR diff before merge
+
+## Acceptance mapping
+
+| Acceptance | Evidence |
+| --- | --- |
+| Stable inputs | `scripts/repobrief_chunk_bridge.py` requires stable chunk id/id, byte range and content hash or derives content hash from text. Tests reject rows without stable range. |
+| External layer | Report marks owner `semantAH`, `repo_brief_core_ranking_changed: false`, `default_use: false`, and does not touch Lenskit/RepoBrief core. |
+| Evaluation before default use | Optional goldset path reports recall, MRR and miss taxonomy; default report status is `not_run` with `promotion_allowed: false`. |
+
+## Validation
+
+```bash
+python -m pytest tests/test_repobrief_chunk_bridge.py tests/test_push_index.py -q
+python -m ruff check scripts/repobrief_chunk_bridge.py tests/test_repobrief_chunk_bridge.py
+git diff --check
+```
+
+Observed local result:
+
+- `17 passed, 1 skipped` (`numpy` missing for one pre-existing optional `push_index` test path)
+- Ruff passed
+- Diff whitespace check passed
+
+## Self-review
+
+No blocker found in this bounded prototype. The main limitation is intentional: the default local embedding is a deterministic stand-in for bridge and evaluation mechanics. It is not evidence that semantic quality improves.
+
+## Non-claims
+
+This proof does not establish answer correctness, semantic correctness, runtime deployment, default-ranking improvement, RepoBrief-core promotion readiness, security correctness, full CI success, or absence of regressions.

--- a/docs/repobrief-chunk-embedding-bridge.md
+++ b/docs/repobrief-chunk-embedding-bridge.md
@@ -23,9 +23,25 @@ or change RepoBrief core ranking.
 
 - external JSONL records suitable for SemantAH/indexd ingestion;
 - optional parquet records;
-- a bridge report with non-claims and optional goldset recall/MRR.
+- a bridge report with non-claims, optional goldset recall/MRR, and optional
+  comparison against an existing RepoBrief retrieval-eval baseline.
+
+Goldset evaluation ranks bridge records by deterministic query-token overlap when
+`query` is present, otherwise by stable input order. This is a bounded evaluation
+mechanic for the external layer, not a production semantic ranking claim.
+
+## Baseline comparison
+
+Use `--baseline-report <retrieval_eval.json>` with `--goldset <goldset.jsonl>` to
+compare bridge metrics against existing RepoBrief retrieval metrics. The baseline
+comparison checks recall, MRR and miss-count regression where the supplied report
+contains those fields.
+
+Missing baseline data leaves `baseline_comparison.status=not_run` or `warn`, and
+`promotion_allowed` remains `false`.
 
 ## Promotion rule
 
 The semantic layer is not a default ranking source. Promotion requires measured
-recall/MRR and miss-taxonomy evidence against existing retrieval baselines.
+recall/MRR and miss-taxonomy evidence against existing retrieval baselines plus a
+later explicit promotion decision.

--- a/docs/repobrief-chunk-embedding-bridge.md
+++ b/docs/repobrief-chunk-embedding-bridge.md
@@ -1,0 +1,31 @@
+# RepoBrief chunk embedding bridge
+
+Status: prototype
+Task: `RPU-V1-T013`
+
+This bridge lets SemantAH build an external semantic layer from existing RepoBrief
+`chunk_index.jsonl` records.
+
+## Boundary
+
+The bridge consumes stable RepoBrief chunk records only:
+
+- stable `chunk_id` / `id`;
+- byte range: `file_path`, `start_byte`, `end_byte`;
+- content hash, preferably `content_sha256` from the range reference.
+
+It does not crawl repositories, refresh RepoBrief snapshots, mutate Git, write PRs,
+or change RepoBrief core ranking.
+
+## Outputs
+
+`scripts/repobrief_chunk_bridge.py` can emit:
+
+- external JSONL records suitable for SemantAH/indexd ingestion;
+- optional parquet records;
+- a bridge report with non-claims and optional goldset recall/MRR.
+
+## Promotion rule
+
+The semantic layer is not a default ranking source. Promotion requires measured
+recall/MRR and miss-taxonomy evidence against existing retrieval baselines.

--- a/scripts/repobrief_chunk_bridge.py
+++ b/scripts/repobrief_chunk_bridge.py
@@ -1,0 +1,299 @@
+#!/usr/bin/env python3
+"""Build a bounded SemantAH embedding layer from RepoBrief chunk_index JSONL.
+
+The bridge consumes existing RepoBrief chunk_index rows only. It does not crawl a
+repository, refresh RepoBrief snapshots, or alter RepoBrief ranking. The output is
+an external semantic-evidence layer that can be measured before any promotion.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import math
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Iterable, Sequence
+
+try:
+    import pandas as pd
+except ModuleNotFoundError:  # pragma: no cover - optional in minimal envs
+    pd = None  # type: ignore[assignment]
+
+KIND = "semantah.repobrief_chunk_embedding_bridge"
+VERSION = "v1"
+DEFAULT_DIM = 8
+DOES_NOT_ESTABLISH = [
+    "answer_correctness",
+    "semantic_correctness",
+    "repository_understanding",
+    "default_ranking_improvement",
+    "repo_understood",
+    "truth",
+]
+
+
+@dataclass(frozen=True)
+class ChunkRecord:
+    record_id: str
+    repo_id: str
+    chunk_id: str
+    text: str
+    file_path: str
+    start_byte: int
+    end_byte: int
+    content_sha256: str
+    range_ref: dict[str, Any]
+    source_row_sha256: str
+    ordinal: int
+
+
+def sha256_bytes(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+def canonical_json(value: Any) -> str:
+    return json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
+
+
+def stable_text_embedding(text: str, *, dim: int = DEFAULT_DIM) -> list[float]:
+    """Deterministic local stand-in embedding for bridge tests and offline evaluation."""
+    if dim < 1 or dim > 4096:
+        raise ValueError("embedding dim must be between 1 and 4096")
+    digest = hashlib.blake2b(text.encode("utf-8"), digest_size=32).digest()
+    values: list[float] = []
+    for i in range(dim):
+        b = digest[i % len(digest)]
+        values.append(round((b / 127.5) - 1.0, 6))
+    norm = math.sqrt(sum(v * v for v in values)) or 1.0
+    return [round(v / norm, 6) for v in values]
+
+
+def read_jsonl(path: Path) -> list[dict[str, Any]]:
+    rows: list[dict[str, Any]] = []
+    for line_no, line in enumerate(path.read_text(encoding="utf-8").splitlines(), start=1):
+        stripped = line.strip()
+        if not stripped:
+            continue
+        try:
+            row = json.loads(stripped)
+        except json.JSONDecodeError as exc:
+            raise ValueError(f"invalid JSONL at line {line_no}: {exc}") from exc
+        if not isinstance(row, dict):
+            raise ValueError(f"chunk_index row {line_no} must be a JSON object")
+        rows.append(row)
+    return rows
+
+
+def _non_empty_string(value: Any) -> str | None:
+    return value if isinstance(value, str) and value.strip() else None
+
+
+def _int_value(value: Any) -> int | None:
+    if isinstance(value, bool):
+        return None
+    return value if isinstance(value, int) else None
+
+
+def _range_from_row(row: dict[str, Any]) -> dict[str, Any] | None:
+    for key in ("content_range_ref", "range_ref", "canonical_range"):
+        candidate = row.get(key)
+        if isinstance(candidate, dict):
+            return candidate
+    if all(k in row for k in ("path", "start_byte", "end_byte")):
+        return {
+            "artifact_role": row.get("artifact_role", "chunk_index_jsonl"),
+            "file_path": row.get("path"),
+            "start_byte": row.get("start_byte"),
+            "end_byte": row.get("end_byte"),
+            "start_line": row.get("start_line"),
+            "end_line": row.get("end_line"),
+            "content_sha256": row.get("content_sha256"),
+        }
+    return None
+
+
+def _content_hash(row: dict[str, Any], text: str, range_ref: dict[str, Any]) -> str:
+    for source in (row, range_ref):
+        value = source.get("content_sha256") or source.get("range_content_sha256")
+        if isinstance(value, str) and len(value) == 64:
+            return value
+    return sha256_bytes(text.encode("utf-8"))
+
+
+def chunk_record_from_row(row: dict[str, Any], *, ordinal: int, default_repo_id: str) -> ChunkRecord:
+    text = _non_empty_string(row.get("content")) or _non_empty_string(row.get("text"))
+    if text is None:
+        raise ValueError(f"row {ordinal} lacks non-empty content/text")
+    chunk_id = _non_empty_string(row.get("chunk_id")) or _non_empty_string(row.get("id"))
+    if chunk_id is None:
+        raise ValueError(f"row {ordinal} lacks stable chunk_id/id")
+    range_ref = _range_from_row(row)
+    if range_ref is None:
+        raise ValueError(f"row {ordinal} lacks stable byte range")
+    file_path = _non_empty_string(range_ref.get("file_path")) or _non_empty_string(row.get("path"))
+    start_byte = _int_value(range_ref.get("start_byte"))
+    end_byte = _int_value(range_ref.get("end_byte"))
+    if file_path is None or start_byte is None or end_byte is None or end_byte <= start_byte:
+        raise ValueError(f"row {ordinal} has invalid file_path/start_byte/end_byte")
+    repo_id = _non_empty_string(row.get("repo_id")) or default_repo_id
+    content_sha256 = _content_hash(row, text, range_ref)
+    row_sha = sha256_bytes(canonical_json(row).encode("utf-8"))
+    record_id = f"repobrief:{repo_id}:{chunk_id}:{content_sha256[:16]}"
+    return ChunkRecord(
+        record_id=record_id,
+        repo_id=repo_id,
+        chunk_id=chunk_id,
+        text=text,
+        file_path=file_path,
+        start_byte=start_byte,
+        end_byte=end_byte,
+        content_sha256=content_sha256,
+        range_ref=dict(range_ref),
+        source_row_sha256=row_sha,
+        ordinal=ordinal,
+    )
+
+
+def build_records(
+    rows: Sequence[dict[str, Any]],
+    *,
+    default_repo_id: str,
+    dim: int = DEFAULT_DIM,
+) -> list[dict[str, Any]]:
+    records: list[dict[str, Any]] = []
+    seen: set[str] = set()
+    for ordinal, row in enumerate(rows):
+        chunk = chunk_record_from_row(row, ordinal=ordinal, default_repo_id=default_repo_id)
+        if chunk.record_id in seen:
+            raise ValueError(f"duplicate stable record id: {chunk.record_id}")
+        seen.add(chunk.record_id)
+        records.append(
+            {
+                "id": chunk.record_id,
+                "doc_id": f"{chunk.repo_id}:{chunk.file_path}",
+                "namespace": "repobrief-chunks",
+                "text": chunk.text,
+                "embedding": stable_text_embedding(chunk.text, dim=dim),
+                "repo_id": chunk.repo_id,
+                "repobrief_chunk_id": chunk.chunk_id,
+                "content_sha256": chunk.content_sha256,
+                "source_row_sha256": chunk.source_row_sha256,
+                "file_path": chunk.file_path,
+                "start_byte": chunk.start_byte,
+                "end_byte": chunk.end_byte,
+                "range_ref": chunk.range_ref,
+                "bridge_input_basis": "repobrief_chunk_index_stable_ids_ranges_hashes",
+            }
+        )
+    return records
+
+
+def evaluate_recall(records: Sequence[dict[str, Any]], goldset: Sequence[dict[str, Any]]) -> dict[str, Any]:
+    by_chunk = {str(r["repobrief_chunk_id"]): idx + 1 for idx, r in enumerate(records)}
+    total = len(goldset)
+    hits = 0
+    reciprocal_sum = 0.0
+    misses: list[dict[str, Any]] = []
+    for item in goldset:
+        expected = item.get("expected_chunk_id")
+        rank = by_chunk.get(str(expected)) if expected is not None else None
+        if rank is None:
+            misses.append({"expected_chunk_id": expected, "reason": "missing_from_bridge_records"})
+            continue
+        hits += 1
+        reciprocal_sum += 1.0 / rank
+    return {
+        "status": "pass" if total == hits else "warn",
+        "gold_count": total,
+        "hit_count": hits,
+        "recall": 1.0 if total == 0 else hits / total,
+        "mrr": 0.0 if total == 0 else reciprocal_sum / total,
+        "miss_taxonomy": misses,
+    }
+
+
+def build_report(
+    *,
+    chunk_index: Path,
+    records: Sequence[dict[str, Any]],
+    goldset: Sequence[dict[str, Any]] | None = None,
+) -> dict[str, Any]:
+    chunk_bytes = chunk_index.read_bytes()
+    report = {
+        "kind": KIND,
+        "version": VERSION,
+        "status": "ok",
+        "chunk_index": str(chunk_index),
+        "chunk_index_sha256": sha256_bytes(chunk_bytes),
+        "record_count": len(records),
+        "input_contract": "stable RepoBrief chunk ids, byte ranges, and content hashes",
+        "external_layer": {
+            "owner": "semantAH",
+            "repo_brief_core_ranking_changed": False,
+            "default_use": False,
+            "promotion_requires_measurement": True,
+        },
+        "mutation_boundary": {
+            "writes": ["external_semantic_records", "bridge_report"],
+            "does_not_mutate": ["repobrief_core", "repo_worktree", "git", "pull_requests"],
+            "does_not_crawl_repo": True,
+        },
+        "does_not_establish": DOES_NOT_ESTABLISH,
+    }
+    if goldset is not None:
+        report["evaluation"] = evaluate_recall(records, goldset)
+    else:
+        report["evaluation"] = {
+            "status": "not_run",
+            "reason": "no_goldset_provided",
+            "promotion_allowed": False,
+        }
+    return report
+
+
+def write_jsonl(path: Path, records: Iterable[dict[str, Any]]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8") as handle:
+        for record in records:
+            handle.write(json.dumps(record, sort_keys=True, ensure_ascii=False) + "\n")
+
+
+def write_parquet(path: Path, records: Sequence[dict[str, Any]]) -> None:
+    if pd is None:
+        raise RuntimeError("pandas is required for parquet output")
+    path.parent.mkdir(parents=True, exist_ok=True)
+    pd.DataFrame(list(records)).to_parquet(path)
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--chunk-index", required=True, type=Path)
+    parser.add_argument("--default-repo-id", default="repo")
+    parser.add_argument("--dim", type=int, default=DEFAULT_DIM)
+    parser.add_argument("--out-jsonl", type=Path)
+    parser.add_argument("--out-parquet", type=Path)
+    parser.add_argument("--report", required=True, type=Path)
+    parser.add_argument("--goldset", type=Path)
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = parse_args(argv)
+    rows = read_jsonl(args.chunk_index)
+    records = build_records(rows, default_repo_id=args.default_repo_id, dim=args.dim)
+    goldset = read_jsonl(args.goldset) if args.goldset else None
+    if args.out_jsonl:
+        write_jsonl(args.out_jsonl, records)
+    if args.out_parquet:
+        write_parquet(args.out_parquet, records)
+    report = build_report(chunk_index=args.chunk_index, records=records, goldset=goldset)
+    args.report.parent.mkdir(parents=True, exist_ok=True)
+    args.report.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    print(json.dumps(report, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/repobrief_chunk_bridge.py
+++ b/scripts/repobrief_chunk_bridge.py
@@ -12,6 +12,7 @@ import argparse
 import hashlib
 import json
 import math
+import re
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Iterable, Sequence
@@ -24,6 +25,7 @@ except ModuleNotFoundError:  # pragma: no cover - optional in minimal envs
 KIND = "semantah.repobrief_chunk_embedding_bridge"
 VERSION = "v1"
 DEFAULT_DIM = 8
+DEFAULT_EVAL_K = 10
 DOES_NOT_ESTABLISH = [
     "answer_correctness",
     "semantic_correctness",
@@ -86,6 +88,13 @@ def read_jsonl(path: Path) -> list[dict[str, Any]]:
     return rows
 
 
+def read_json(path: Path) -> dict[str, Any]:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError(f"JSON report must be an object: {path}")
+    return payload
+
+
 def _non_empty_string(value: Any) -> str | None:
     return value if isinstance(value, str) and value.strip() else None
 
@@ -132,7 +141,9 @@ def chunk_record_from_row(row: dict[str, Any], *, ordinal: int, default_repo_id:
     range_ref = _range_from_row(row)
     if range_ref is None:
         raise ValueError(f"row {ordinal} lacks stable byte range")
-    file_path = _non_empty_string(range_ref.get("file_path")) or _non_empty_string(row.get("path"))
+    file_path = _non_empty_string(range_ref.get("file_path")) or _non_empty_string(
+        row.get("path")
+    )
     start_byte = _int_value(range_ref.get("start_byte"))
     end_byte = _int_value(range_ref.get("end_byte"))
     if file_path is None or start_byte is None or end_byte is None or end_byte <= start_byte:
@@ -190,27 +201,207 @@ def build_records(
     return records
 
 
-def evaluate_recall(records: Sequence[dict[str, Any]], goldset: Sequence[dict[str, Any]]) -> dict[str, Any]:
-    by_chunk = {str(r["repobrief_chunk_id"]): idx + 1 for idx, r in enumerate(records)}
+def _tokens(value: str) -> set[str]:
+    return {token for token in re.split(r"[^A-Za-z0-9_]+", value.lower()) if token}
+
+
+def _query_score(record: dict[str, Any], query: str) -> tuple[int, int, str, str]:
+    query_tokens = _tokens(query)
+    haystack = " ".join(
+        [
+            str(record.get("text", "")),
+            str(record.get("file_path", "")),
+            str(record.get("repobrief_chunk_id", "")),
+        ]
+    )
+    record_tokens = _tokens(haystack)
+    overlap = len(query_tokens & record_tokens)
+    phrase_bonus = 1 if query.lower() in haystack.lower() else 0
+    return (
+        -(overlap + phrase_bonus),
+        len(str(record.get("file_path", ""))),
+        str(record.get("file_path", "")),
+        str(record.get("repobrief_chunk_id", "")),
+    )
+
+
+def _rank_records(records: Sequence[dict[str, Any]], query: str | None) -> list[dict[str, Any]]:
+    if not query:
+        return list(records)
+    return sorted(records, key=lambda record: _query_score(record, query))
+
+
+def evaluate_recall(
+    records: Sequence[dict[str, Any]],
+    goldset: Sequence[dict[str, Any]],
+    *,
+    k: int = DEFAULT_EVAL_K,
+) -> dict[str, Any]:
     total = len(goldset)
     hits = 0
     reciprocal_sum = 0.0
     misses: list[dict[str, Any]] = []
+    case_details: list[dict[str, Any]] = []
+
     for item in goldset:
         expected = item.get("expected_chunk_id")
-        rank = by_chunk.get(str(expected)) if expected is not None else None
+        query = _non_empty_string(item.get("query"))
+        ranked = _rank_records(records, query)
+        top_k = ranked[:k]
+        top_ids = [str(r["repobrief_chunk_id"]) for r in top_k]
+        rank = None
+        if expected is not None:
+            for idx, record in enumerate(ranked, start=1):
+                if str(record.get("repobrief_chunk_id")) == str(expected):
+                    rank = idx
+                    break
         if rank is None:
-            misses.append({"expected_chunk_id": expected, "reason": "missing_from_bridge_records"})
+            miss_reason = "missing_from_bridge_records"
+            misses.append({"expected_chunk_id": expected, "reason": miss_reason})
+            case_details.append(
+                {
+                    "query": query,
+                    "expected_chunk_id": expected,
+                    "rank": None,
+                    "top_k": top_ids,
+                    "hit": False,
+                    "miss_type": miss_reason,
+                }
+            )
             continue
-        hits += 1
-        reciprocal_sum += 1.0 / rank
+        hit = rank <= k
+        if hit:
+            hits += 1
+            reciprocal_sum += 1.0 / rank
+            miss_type = None
+        else:
+            miss_type = "expected_rank_below_k"
+            misses.append({"expected_chunk_id": expected, "reason": miss_type, "rank": rank})
+        case_details.append(
+            {
+                "query": query,
+                "expected_chunk_id": expected,
+                "rank": rank,
+                "top_k": top_ids,
+                "hit": hit,
+                "miss_type": miss_type,
+            }
+        )
+
     return {
         "status": "pass" if total == hits else "warn",
         "gold_count": total,
         "hit_count": hits,
+        "k": k,
         "recall": 1.0 if total == 0 else hits / total,
         "mrr": 0.0 if total == 0 else reciprocal_sum / total,
+        "rank_basis": "query_token_overlap_when_query_present_else_record_order",
         "miss_taxonomy": misses,
+        "cases": case_details,
+    }
+
+
+def _normalise_metric(value: Any) -> float | None:
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        return None
+    metric = float(value)
+    if metric > 1.0:
+        metric = metric / 100.0
+    return metric
+
+
+def _baseline_recall(metrics: dict[str, Any]) -> float | None:
+    for key in ("recall@10", "recall", "recall_at_10"):
+        metric = _normalise_metric(metrics.get(key))
+        if metric is not None:
+            return metric
+    return None
+
+
+def _baseline_mrr(metrics: dict[str, Any]) -> float | None:
+    for key in ("mrr", "MRR"):
+        metric = _normalise_metric(metrics.get(key))
+        if metric is not None:
+            return metric
+    return None
+
+
+def _baseline_miss_count(report: dict[str, Any]) -> int | None:
+    metrics = report.get("metrics")
+    if isinstance(metrics, dict):
+        for key in ("misses", "miss_count", "total_misses"):
+            value = metrics.get(key)
+            if isinstance(value, int) and not isinstance(value, bool):
+                return value
+    taxonomy = report.get("miss_taxonomy")
+    if isinstance(taxonomy, dict):
+        aggregate = taxonomy.get("aggregate")
+        if isinstance(aggregate, dict):
+            value = aggregate.get("total_misses")
+            if isinstance(value, int) and not isinstance(value, bool):
+                return value
+    details = report.get("details")
+    if isinstance(details, list):
+        return sum(1 for item in details if isinstance(item, dict) and not item.get("is_relevant"))
+    return None
+
+
+def compare_to_baseline(
+    bridge_eval: dict[str, Any], baseline_report: dict[str, Any]
+) -> dict[str, Any]:
+    metrics = baseline_report.get("metrics")
+    if not isinstance(metrics, dict):
+        return {
+            "status": "warn",
+            "reason": "baseline_metrics_missing",
+            "promotion_allowed": False,
+        }
+
+    baseline_recall = _baseline_recall(metrics)
+    baseline_mrr = _baseline_mrr(metrics)
+    baseline_misses = _baseline_miss_count(baseline_report)
+    bridge_recall = _normalise_metric(bridge_eval.get("recall"))
+    bridge_mrr = _normalise_metric(bridge_eval.get("mrr"))
+    bridge_misses = len(bridge_eval.get("miss_taxonomy", []))
+
+    blockers: list[str] = []
+    if baseline_recall is None:
+        blockers.append("baseline_recall_missing")
+    elif bridge_recall is None or bridge_recall < baseline_recall:
+        blockers.append("recall_regression")
+    if baseline_mrr is None:
+        blockers.append("baseline_mrr_missing")
+    elif bridge_mrr is None or bridge_mrr < baseline_mrr:
+        blockers.append("mrr_regression")
+    if baseline_misses is not None and bridge_misses > baseline_misses:
+        blockers.append("miss_taxonomy_regression")
+
+    return {
+        "status": "pass" if not blockers else "warn",
+        "promotion_allowed": False,
+        "promotion_rule": "default use requires explicit later decision after measured baseline comparison",
+        "baseline_metrics": {
+            "recall": baseline_recall,
+            "mrr": baseline_mrr,
+            "miss_count": baseline_misses,
+        },
+        "bridge_metrics": {
+            "recall": bridge_recall,
+            "mrr": bridge_mrr,
+            "miss_count": bridge_misses,
+        },
+        "deltas": {
+            "recall": None
+            if baseline_recall is None or bridge_recall is None
+            else bridge_recall - baseline_recall,
+            "mrr": None
+            if baseline_mrr is None or bridge_mrr is None
+            else bridge_mrr - baseline_mrr,
+            "miss_count": None
+            if baseline_misses is None
+            else bridge_misses - baseline_misses,
+        },
+        "blockers": blockers,
     }
 
 
@@ -219,6 +410,8 @@ def build_report(
     chunk_index: Path,
     records: Sequence[dict[str, Any]],
     goldset: Sequence[dict[str, Any]] | None = None,
+    baseline_report: dict[str, Any] | None = None,
+    k: int = DEFAULT_EVAL_K,
 ) -> dict[str, Any]:
     chunk_bytes = chunk_index.read_bytes()
     report = {
@@ -243,11 +436,25 @@ def build_report(
         "does_not_establish": DOES_NOT_ESTABLISH,
     }
     if goldset is not None:
-        report["evaluation"] = evaluate_recall(records, goldset)
+        report["evaluation"] = evaluate_recall(records, goldset, k=k)
     else:
         report["evaluation"] = {
             "status": "not_run",
             "reason": "no_goldset_provided",
+            "promotion_allowed": False,
+        }
+
+    if goldset is not None and baseline_report is not None:
+        report["baseline_comparison"] = compare_to_baseline(
+            report["evaluation"], baseline_report
+        )
+    else:
+        reason = "no_baseline_report_provided"
+        if goldset is None:
+            reason = "no_goldset_provided"
+        report["baseline_comparison"] = {
+            "status": "not_run",
+            "reason": reason,
             "promotion_allowed": False,
         }
     return report
@@ -272,10 +479,12 @@ def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
     parser.add_argument("--chunk-index", required=True, type=Path)
     parser.add_argument("--default-repo-id", default="repo")
     parser.add_argument("--dim", type=int, default=DEFAULT_DIM)
+    parser.add_argument("--eval-k", type=int, default=DEFAULT_EVAL_K)
     parser.add_argument("--out-jsonl", type=Path)
     parser.add_argument("--out-parquet", type=Path)
     parser.add_argument("--report", required=True, type=Path)
     parser.add_argument("--goldset", type=Path)
+    parser.add_argument("--baseline-report", type=Path)
     return parser.parse_args(argv)
 
 
@@ -284,13 +493,22 @@ def main(argv: Sequence[str] | None = None) -> int:
     rows = read_jsonl(args.chunk_index)
     records = build_records(rows, default_repo_id=args.default_repo_id, dim=args.dim)
     goldset = read_jsonl(args.goldset) if args.goldset else None
+    baseline_report = read_json(args.baseline_report) if args.baseline_report else None
     if args.out_jsonl:
         write_jsonl(args.out_jsonl, records)
     if args.out_parquet:
         write_parquet(args.out_parquet, records)
-    report = build_report(chunk_index=args.chunk_index, records=records, goldset=goldset)
+    report = build_report(
+        chunk_index=args.chunk_index,
+        records=records,
+        goldset=goldset,
+        baseline_report=baseline_report,
+        k=args.eval_k,
+    )
     args.report.parent.mkdir(parents=True, exist_ok=True)
-    args.report.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    args.report.write_text(
+        json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+    )
     print(json.dumps(report, indent=2, sort_keys=True))
     return 0
 

--- a/tests/test_repobrief_chunk_bridge.py
+++ b/tests/test_repobrief_chunk_bridge.py
@@ -1,0 +1,113 @@
+import hashlib
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from scripts import repobrief_chunk_bridge as bridge
+
+
+def _sha(text: str) -> str:
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+def _row(text="hello semantic bridge"):
+    return {
+        "repo_id": "demo",
+        "chunk_id": "c1",
+        "path": "README.md",
+        "content": text,
+        "content_range_ref": {
+            "artifact_role": "canonical_md",
+            "file_path": "README.md",
+            "start_byte": 10,
+            "end_byte": 31,
+            "start_line": 2,
+            "end_line": 2,
+            "content_sha256": _sha(text),
+        },
+    }
+
+
+def test_build_records_preserves_stable_repobrief_identity():
+    records = bridge.build_records([_row()], default_repo_id="fallback", dim=6)
+
+    assert len(records) == 1
+    rec = records[0]
+    assert rec["id"].startswith("repobrief:demo:c1:")
+    assert rec["repo_id"] == "demo"
+    assert rec["repobrief_chunk_id"] == "c1"
+    assert rec["file_path"] == "README.md"
+    assert rec["start_byte"] == 10
+    assert rec["end_byte"] == 31
+    assert rec["content_sha256"] == _sha("hello semantic bridge")
+    assert rec["bridge_input_basis"] == "repobrief_chunk_index_stable_ids_ranges_hashes"
+    assert len(rec["embedding"]) == 6
+
+
+def test_build_records_rejects_unstable_rows_without_range():
+    bad = {"repo_id": "demo", "chunk_id": "c1", "content": "hello"}
+
+    with pytest.raises(ValueError, match="lacks stable byte range"):
+        bridge.build_records([bad], default_repo_id="fallback")
+
+
+def test_report_keeps_semantic_layer_external_and_non_promoted(tmp_path: Path):
+    chunk_index = tmp_path / "demo.chunk_index.jsonl"
+    chunk_index.write_text(json.dumps(_row()) + "\n", encoding="utf-8")
+    records = bridge.build_records(bridge.read_jsonl(chunk_index), default_repo_id="fallback")
+
+    report = bridge.build_report(chunk_index=chunk_index, records=records)
+
+    assert report["external_layer"]["owner"] == "semantAH"
+    assert report["external_layer"]["repo_brief_core_ranking_changed"] is False
+    assert report["external_layer"]["default_use"] is False
+    assert report["evaluation"]["status"] == "not_run"
+    assert "default_ranking_improvement" in report["does_not_establish"]
+
+
+def test_goldset_eval_reports_recall_and_misses():
+    records = bridge.build_records([_row(), {**_row("other"), "chunk_id": "c2"}], default_repo_id="demo")
+    result = bridge.evaluate_recall(records, [{"expected_chunk_id": "c2"}, {"expected_chunk_id": "missing"}])
+
+    assert result["status"] == "warn"
+    assert result["gold_count"] == 2
+    assert result["hit_count"] == 1
+    assert result["recall"] == 0.5
+    assert result["miss_taxonomy"] == [{"expected_chunk_id": "missing", "reason": "missing_from_bridge_records"}]
+
+
+def test_cli_writes_external_jsonl_and_report(tmp_path: Path):
+    chunk_index = tmp_path / "demo.chunk_index.jsonl"
+    out_jsonl = tmp_path / "semantah.records.jsonl"
+    report = tmp_path / "bridge.report.json"
+    chunk_index.write_text(json.dumps(_row()) + "\n", encoding="utf-8")
+
+    proc = subprocess.run(
+        [
+            sys.executable,
+            "scripts/repobrief_chunk_bridge.py",
+            "--chunk-index",
+            str(chunk_index),
+            "--out-jsonl",
+            str(out_jsonl),
+            "--report",
+            str(report),
+            "--dim",
+            "4",
+        ],
+        cwd=Path(__file__).parent.parent,
+        text=True,
+        capture_output=True,
+        check=True,
+    )
+
+    written = [json.loads(line) for line in out_jsonl.read_text(encoding="utf-8").splitlines()]
+    payload = json.loads(report.read_text(encoding="utf-8"))
+    assert proc.returncode == 0
+    assert len(written) == 1
+    assert len(written[0]["embedding"]) == 4
+    assert payload["kind"] == "semantah.repobrief_chunk_embedding_bridge"
+    assert payload["record_count"] == 1

--- a/tests/test_repobrief_chunk_bridge.py
+++ b/tests/test_repobrief_chunk_bridge.py
@@ -13,15 +13,15 @@ def _sha(text: str) -> str:
     return hashlib.sha256(text.encode("utf-8")).hexdigest()
 
 
-def _row(text="hello semantic bridge"):
+def _row(text="hello semantic bridge", chunk_id="c1", path="README.md"):
     return {
         "repo_id": "demo",
-        "chunk_id": "c1",
-        "path": "README.md",
+        "chunk_id": chunk_id,
+        "path": path,
         "content": text,
         "content_range_ref": {
             "artifact_role": "canonical_md",
-            "file_path": "README.md",
+            "file_path": path,
             "start_byte": 10,
             "end_byte": 31,
             "start_line": 2,
@@ -65,25 +65,107 @@ def test_report_keeps_semantic_layer_external_and_non_promoted(tmp_path: Path):
     assert report["external_layer"]["repo_brief_core_ranking_changed"] is False
     assert report["external_layer"]["default_use"] is False
     assert report["evaluation"]["status"] == "not_run"
+    assert report["baseline_comparison"] == {
+        "status": "not_run",
+        "reason": "no_goldset_provided",
+        "promotion_allowed": False,
+    }
     assert "default_ranking_improvement" in report["does_not_establish"]
 
 
-def test_goldset_eval_reports_recall_and_misses():
-    records = bridge.build_records([_row(), {**_row("other"), "chunk_id": "c2"}], default_repo_id="demo")
-    result = bridge.evaluate_recall(records, [{"expected_chunk_id": "c2"}, {"expected_chunk_id": "missing"}])
+def test_goldset_eval_reports_query_ranked_recall_mrr_and_misses():
+    records = bridge.build_records(
+        [
+            _row("unrelated setup", chunk_id="c1"),
+            _row("semantic bridge baseline evidence", chunk_id="c2"),
+        ],
+        default_repo_id="demo",
+    )
+    result = bridge.evaluate_recall(
+        records,
+        [
+            {"query": "semantic bridge evidence", "expected_chunk_id": "c2"},
+            {"query": "missing target", "expected_chunk_id": "missing"},
+        ],
+    )
 
     assert result["status"] == "warn"
     assert result["gold_count"] == 2
     assert result["hit_count"] == 1
     assert result["recall"] == 0.5
-    assert result["miss_taxonomy"] == [{"expected_chunk_id": "missing", "reason": "missing_from_bridge_records"}]
+    assert result["mrr"] == 0.5
+    assert result["cases"][0]["rank"] == 1
+    assert result["miss_taxonomy"] == [
+        {"expected_chunk_id": "missing", "reason": "missing_from_bridge_records"}
+    ]
 
 
-def test_cli_writes_external_jsonl_and_report(tmp_path: Path):
+def test_baseline_comparison_is_required_for_promotion_claims(tmp_path: Path):
+    chunk_index = tmp_path / "demo.chunk_index.jsonl"
+    chunk_index.write_text(json.dumps(_row()) + "\n", encoding="utf-8")
+    records = bridge.build_records(bridge.read_jsonl(chunk_index), default_repo_id="fallback")
+    goldset = [{"query": "semantic bridge", "expected_chunk_id": "c1"}]
+    baseline = {
+        "metrics": {"recall@10": 50.0, "mrr": 0.25},
+        "miss_taxonomy": {"aggregate": {"total_misses": 1}},
+    }
+
+    report = bridge.build_report(
+        chunk_index=chunk_index,
+        records=records,
+        goldset=goldset,
+        baseline_report=baseline,
+    )
+
+    comparison = report["baseline_comparison"]
+    assert comparison["status"] == "pass"
+    assert comparison["promotion_allowed"] is False
+    assert comparison["baseline_metrics"] == {
+        "recall": 0.5,
+        "mrr": 0.25,
+        "miss_count": 1,
+    }
+    assert comparison["bridge_metrics"] == {
+        "recall": 1.0,
+        "mrr": 1.0,
+        "miss_count": 0,
+    }
+    assert comparison["deltas"] == {"recall": 0.5, "mrr": 0.75, "miss_count": -1}
+
+
+def test_baseline_comparison_warns_on_recall_mrr_or_miss_regression():
+    bridge_eval = {"recall": 0.4, "mrr": 0.2, "miss_taxonomy": [{"x": 1}]}
+    baseline = {
+        "metrics": {"recall@10": 0.5, "mrr": 0.25},
+        "miss_taxonomy": {"aggregate": {"total_misses": 0}},
+    }
+
+    comparison = bridge.compare_to_baseline(bridge_eval, baseline)
+
+    assert comparison["status"] == "warn"
+    assert comparison["blockers"] == [
+        "recall_regression",
+        "mrr_regression",
+        "miss_taxonomy_regression",
+    ]
+    assert comparison["promotion_allowed"] is False
+
+
+def test_cli_writes_external_jsonl_report_and_baseline_comparison(tmp_path: Path):
     chunk_index = tmp_path / "demo.chunk_index.jsonl"
     out_jsonl = tmp_path / "semantah.records.jsonl"
     report = tmp_path / "bridge.report.json"
+    goldset = tmp_path / "goldset.jsonl"
+    baseline = tmp_path / "baseline.json"
     chunk_index.write_text(json.dumps(_row()) + "\n", encoding="utf-8")
+    goldset.write_text(
+        json.dumps({"query": "semantic bridge", "expected_chunk_id": "c1"}) + "\n",
+        encoding="utf-8",
+    )
+    baseline.write_text(
+        json.dumps({"metrics": {"recall@10": 1.0, "mrr": 1.0}, "details": []}),
+        encoding="utf-8",
+    )
 
     proc = subprocess.run(
         [
@@ -97,6 +179,10 @@ def test_cli_writes_external_jsonl_and_report(tmp_path: Path):
             str(report),
             "--dim",
             "4",
+            "--goldset",
+            str(goldset),
+            "--baseline-report",
+            str(baseline),
         ],
         cwd=Path(__file__).parent.parent,
         text=True,
@@ -111,3 +197,4 @@ def test_cli_writes_external_jsonl_and_report(tmp_path: Path):
     assert len(written[0]["embedding"]) == 4
     assert payload["kind"] == "semantah.repobrief_chunk_embedding_bridge"
     assert payload["record_count"] == 1
+    assert payload["baseline_comparison"]["status"] == "pass"


### PR DESCRIPTION
## Summary

- adds a bounded SemantAH bridge for existing RepoBrief `chunk_index.jsonl` records
- preserves stable chunk ids, byte ranges, content hashes and source row hashes as bridge inputs
- keeps semantic records outside RepoBrief core ranking and reports non-claims plus optional recall/MRR/miss taxonomy
- documents the boundary and promotion rule

## Validation

- `python -m pytest tests/test_repobrief_chunk_bridge.py tests/test_push_index.py -q` → 17 passed, 1 skipped (numpy not installed for one existing optional push-index test)
- `python -m ruff check scripts/repobrief_chunk_bridge.py tests/test_repobrief_chunk_bridge.py` → pass
- `git diff --cached --check` before commit → pass

## Boundary

This PR does not change RepoBrief core ranking, does not crawl repositories, does not refresh RepoBrief snapshots, and does not establish answer correctness, semantic correctness, default-ranking improvement, runtime deployment, or full regression absence.

Task: RPU-V1-T013