### PR TITLE
docs: migrate system context to primary sources

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,14 +236,14 @@ Der Dienst dokumentiert seine Routen in [docs/indexd-api.md](docs/indexd-api.md)
 ## WGX-Integration (Stub)
 Siehe `docs/wgx-konzept.md` und `.wgx/profile.yml`. Ziel: reproduzierbare Orchestrierung (devcontainer/Devbox/mise/direnv bevorzugt).
 
-## Organismus-Kontext
+## Systemkontext
 
-Dieses Repository ist Teil des **Heimgewebe-Organismus**.
+Der aktuelle Zweck, Lifecycle-Status und die Beziehungen dieses Repositories zu anderen
+Heimgewebe-Systemen werden im [Systemkatalog](https://github.com/heimgewebe/systemkatalog) geführt. Die
+[gerenderte Systemübersicht](https://github.com/heimgewebe/systemkatalog/blob/main/rendered/system-catalog.md)
+ist die lesbare Gesamtsicht; die
+[maschinenlesbare Inventur](https://github.com/heimgewebe/systemkatalog/blob/main/registry/ecosystem/nodes.json)
+ist die Quelle für Automatisierung.
 
-Die übergeordnete Architektur, Achsen, Rollen und Contracts sind zentral beschrieben im  
-👉 [`metarepo/docs/heimgewebe-organismus.md`](https://github.com/heimgewebe/metarepo/blob/main/docs/heimgewebe-organismus.md)  
-sowie im Zielbild  
-👉 [`metarepo/docs/heimgewebe-zielbild.md`](https://github.com/heimgewebe/metarepo/blob/main/docs/heimgewebe-zielbild.md).
-
-Alle Rollen-Definitionen, Datenflüsse und Contract-Zuordnungen dieses Repos
-sind dort verankert.
+Repositoryeigene Betriebs-, Daten- und Implementierungswahrheit bleibt in diesem Repository.
+Gemeinsame Contracts bleiben bei ihrer jeweiligen Primärquelle.

--- a/contracts/examples/knowledge.observatory.example.json
+++ b/contracts/examples/knowledge.observatory.example.json
@@ -11,7 +11,7 @@
       "confidence": 0.85,
       "sources": [
         { "type": "event", "ref": "event-123", "weight": 0.9 },
-        { "type": "repo_file", "ref": "docs/system/heimgewebe-zielbild.md", "weight": 0.5 }
+        { "type": "repo_file", "ref": "docs/semantAH/observatory.md", "weight": 0.5 }
       ],
       "suggested_questions": [
         "Is the drift accelerating?",

--- a/docs/semantAH-feedback-loop.md
+++ b/docs/semantAH-feedback-loop.md
@@ -1,5 +1,9 @@
 # semantAH Feedback-Loop
 
+> **Historischer Konzeptstand:** Dieses Dokument bewahrt die frühere Organismusmetapher und
+> beschreibt keine aktuelle System- oder Rollenwahrheit. Der heutige Zweck und Lifecycle-Status
+> von `semantAH` werden im [Systemkatalog](https://github.com/heimgewebe/systemkatalog) geführt.
+
 Dieses Dokument beschreibt, wie semantAH als semantisches Observatorium
 Signale an den Heimgewebe-Organismus zurückgeben soll – und wie daraus
 Policies für Selbstverbesserung entstehen können.

--- a/docs/semantAH/comprehensive-optimization-strategy.md
+++ b/docs/semantAH/comprehensive-optimization-strategy.md
@@ -1,5 +1,9 @@
 # semantAH: Umfassende Optimierungsstrategie und Architektur-Analyse
 
+> **Historischer Konzeptstand:** Die folgenden Organismus- und Rollenbilder sind nicht normativ.
+> Aktuelle Systemzwecke und Beziehungen werden im [Systemkatalog](https://github.com/heimgewebe/systemkatalog) geführt; technische
+> Aussagen sind gegen den heutigen Repositoryzustand zu prüfen.
+
 Dieses Dokument vereint die technische Architektur-Analyse mit den semantischen Optimierungsstrategien, um *semantAH* zu einem robusten, leistungsfähigen und „verständigen“ Wissens-Organ im Heimgewebe-Organismus zu entwickeln.
 
 ## 1. Überblick über den aktuellen Stand

--- a/docs/semantAH/observatory.md
+++ b/docs/semantAH/observatory.md
@@ -273,7 +273,7 @@ Das Observatory selbst hat **keine Meinung** zu seiner Ungewissheit. Es meldet F
 ### Producer-Semantik
 Das Schema setzt `producer: "semantAH"` konstant. Technisch wird der Endpoint von `indexd` bereitgestellt, einem Sub-Service von semantAH. 
 
-**Aktueller Stand**: `producer="semantAH"` repräsentiert das Organ im Heimgewebe-Organismus.
+**Aktueller Stand**: `producer="semantAH"` identifiziert die veröffentlichende Komponente. Die organisationsweite Rolle wird im Systemkatalog geführt.
 
 **Alternativen für zukünftige Versionen**:
 - `producer="indexd"` (technisch präziser)


### PR DESCRIPTION
## Zweck

SemantAH soll keine aktuelle Organisationsrolle aus historisierten Metarepo-Dokumenten ableiten; repositoryeigene Wissensquellen bleiben lokal.

## Änderung

- README auf Systemkatalog umgestellt
- Observatory-Beispiel auf `docs/semantAH/observatory.md` als repositoryeigene Quelle umgestellt
- alte Organismus-Konzepttexte ausdrücklich historisch und nicht normativ markiert
- Producer-Semantik von einer Organisationsrolle getrennt

## Prüfung

- Ruff grün
- Observatory-Beispiel schema-valide
- 108 Tests bestanden
- T006-Drift-, Ziel- und Whitespace-Gate bestanden

## Unabhängiger Bestandsbefund

`tests/test_push_index_e2e.py` bindet Port 8080 fest. Der Port war durch einen fremden Dienst belegt; dieser Prozess wurde nicht beendet. Die Porthärtung wird separat im Bureau registriert.

Bureau: `METAREPO-LEGACY-RECONCILIATION-V1-T006`