### PR TITLE
fix(indexd): make E2E bind address portable

### DIFF
--- a/crates/indexd/README.md
+++ b/crates/indexd/README.md
@@ -4,7 +4,7 @@
 
 ## Komponenten
 - `AppState`: verwaltet den `VectorStore` (RW-Lock) und kann in Tests ersetzt werden.
-- `run`: Hilfsfunktion, die den Server unter `0.0.0.0:8080` startet und zusätzliche Routen injiziert.
+- `run`: Hilfsfunktion, die den Server standardmäßig unter `0.0.0.0:8080` startet und zusätzliche Routen injiziert. Für isolierte Tests oder abweichende Laufzeitumgebungen kann die Bind-Adresse über `INDEXD_BIND_ADDR` gesetzt werden, zum Beispiel `127.0.0.1:49152`.
 - `store`-Modul: In-Memory-Vektorablage mit Namensraum-Unterstützung und einfacher Persistenz-Erweiterbarkeit.
 
 ## HTTP-API

--- a/crates/indexd/src/lib.rs
+++ b/crates/indexd/src/lib.rs
@@ -12,6 +12,8 @@ use tokio::{net::TcpListener, signal};
 use tracing::{info, warn, Level};
 use tracing_subscriber::FmtSubscriber;
 
+const DEFAULT_BIND_ADDR: &str = "0.0.0.0:8080";
+
 pub struct AppState {
     pub store: Arc<RwLock<store::VectorStore>>,
     embedder: Option<Arc<dyn Embedder>>,
@@ -68,7 +70,8 @@ pub fn router(state: Arc<AppState>) -> Router {
         .with_state(state)
 }
 
-/// Startet den Server auf 0.0.0.0:8080 und merged die vom Caller gelieferten Routen.
+/// Startet den Server auf `INDEXD_BIND_ADDR` (Default: `0.0.0.0:8080`) und
+/// merged die vom Caller gelieferten Routen.
 pub async fn run(
     build_routes: impl FnOnce(Arc<AppState>) -> Router + Send + 'static,
 ) -> anyhow::Result<()> {
@@ -80,7 +83,7 @@ pub async fn run(
 
     let router = build_routes(state.clone()).merge(router(state.clone()));
 
-    let addr: SocketAddr = "0.0.0.0:8080".parse()?;
+    let addr = bind_addr_from_env()?;
     info!(%addr, "starting indexd");
 
     let listener = TcpListener::bind(addr).await?;
@@ -94,6 +97,24 @@ pub async fn run(
 
     info!("indexd stopped");
     Ok(())
+}
+
+fn bind_addr_from_env() -> anyhow::Result<SocketAddr> {
+    match env::var("INDEXD_BIND_ADDR") {
+        Ok(raw) => parse_bind_addr(&raw),
+        Err(env::VarError::NotPresent) => parse_bind_addr(DEFAULT_BIND_ADDR),
+        Err(env::VarError::NotUnicode(_)) => {
+            anyhow::bail!("INDEXD_BIND_ADDR must contain valid UTF-8")
+        }
+    }
+}
+
+fn parse_bind_addr(raw: &str) -> anyhow::Result<SocketAddr> {
+    raw.parse().map_err(|err| {
+        anyhow::anyhow!(
+            "INDEXD_BIND_ADDR must be a socket address such as 127.0.0.1:8080, got {raw:?}: {err}"
+        )
+    })
 }
 
 fn maybe_init_embedder() -> anyhow::Result<Option<Arc<dyn Embedder>>> {
@@ -208,4 +229,21 @@ async fn shutdown_signal() {
 
 async fn healthz() -> &'static str {
     "ok"
+}
+
+#[cfg(test)]
+mod bind_addr_tests {
+    use super::*;
+
+    #[test]
+    fn parses_explicit_loopback_bind_address() {
+        let addr = parse_bind_addr("127.0.0.1:49152").expect("valid bind address");
+        assert_eq!(addr, SocketAddr::from(([127, 0, 0, 1], 49152)));
+    }
+
+    #[test]
+    fn rejects_bind_address_without_port() {
+        let err = parse_bind_addr("127.0.0.1").expect_err("port is required");
+        assert!(err.to_string().contains("INDEXD_BIND_ADDR"));
+    }
 }

--- a/tests/test_push_index_e2e.py
+++ b/tests/test_push_index_e2e.py
@@ -2,6 +2,7 @@ import json
 import os
 import shlex
 import signal
+import socket
 import subprocess
 import sys
 import time
@@ -77,18 +78,55 @@ def _wait_for_healthz(base: str, deadline_s: float = 15.0):
 
 
 @contextmanager
-def run_indexd():
-    """
-    Baut 'indexd' vorab, startet dann 'cargo run -p indexd' im Hintergrund auf Port 8080,
-    wartet auf /healthz (mit großzügiger Deadline) und räumt beim Verlassen auf.
-    """
-    # 0) Vorab-Build (kann auf kalten CI-Runnern mehrere Minuten dauern)
+def _occupy_default_port():
+    """Keep port 8080 occupied, or preserve an existing foreign owner."""
+    listener = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    listener.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    try:
+        listener.bind(("127.0.0.1", 8080))
+        listener.listen()
+    except OSError:
+        listener.close()
+        yield
+        return
+
+    try:
+        yield
+    finally:
+        listener.close()
+
+
+def _free_tcp_port() -> int:
+    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    try:
+        sock.bind(("127.0.0.1", 0))
+        return int(sock.getsockname()[1])
+    finally:
+        sock.close()
+
+
+def _stop_process(proc: subprocess.Popen[bytes]) -> bytes:
+    if proc.poll() is None:
+        proc.send_signal(signal.SIGINT)
+    try:
+        stdout, _ = proc.communicate(timeout=5)
+    except subprocess.TimeoutExpired:
+        proc.kill()
+        stdout, _ = proc.communicate(timeout=5)
+    return stdout or b""
+
+
+@contextmanager
+def run_indexd(tmp_path: Path):
+    """Start indexd on a free loopback port, wait for readiness, and clean up."""
     _prebuild_indexd()
+    port = _free_tcp_port()
+    base = f"http://127.0.0.1:{port}"
     env = os.environ.copy()
-    # persistenz in tmp, damit Tests nichts in echte Arbeitsverzeichnisse schreiben
-    tmp_state = Path.cwd() / ".test-indexd-state"
-    tmp_state.mkdir(exist_ok=True)
-    env["INDEXD_DB_PATH"] = str(tmp_state / "store.jsonl")
+    state_dir = tmp_path / "indexd-state"
+    state_dir.mkdir()
+    env["INDEXD_DB_PATH"] = str(state_dir / "store.jsonl")
+    env["INDEXD_BIND_ADDR"] = f"127.0.0.1:{port}"
 
     proc = subprocess.Popen(
         ["cargo", "run", "-q", "-p", "indexd"],
@@ -97,82 +135,82 @@ def run_indexd():
         env=env,
     )
     try:
-        # 1) Auf Health warten – großzügige Default-Deadline, via ENV überschreibbar
         _wait_for_healthz(
-            "http://127.0.0.1:8080",
+            base,
             deadline_s=_healthz_deadline_from_env(default=120.0),
         )
-        yield proc
+        yield base, proc
     finally:
-        # Sauber beenden
-        try:
-            proc.send_signal(signal.SIGINT)
-            try:
-                proc.wait(timeout=5)
-            except subprocess.TimeoutExpired:
-                proc.kill()
-        finally:
-            # Logausgabe im Fehlerfall anhängen
-            if proc.stdout:
-                out = proc.stdout.read().decode("utf-8", "replace")
-                sys.stdout.write("\n[indexd output]\n")
-                sys.stdout.write(out)
-                sys.stdout.write("\n[/indexd output]\n")
+        output = _stop_process(proc)
+        if output:
+            sys.stdout.write("\n[indexd output]\n")
+            sys.stdout.write(output.decode("utf-8", "replace"))
+            sys.stdout.write("\n[/indexd output]\n")
 
 
 @pytest.mark.integration
-def test_push_index_script_end_to_end(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
-    # 1) Start server
-    with run_indexd():
-        base = "http://127.0.0.1:8080"
+def test_push_index_script_end_to_end(tmp_path: Path):
+    # Port 8080 remains occupied while indexd runs on an explicit free port.
+    server = None
+    with _occupy_default_port():
+        with pytest.raises(RuntimeError, match="cleanup sentinel"):
+            with run_indexd(tmp_path) as (base, server):
+                assert not base.endswith(":8080")
 
-        # 2) Schreibe Minimal-Parquet in isoliertem Arbeitsverzeichnis
-        work = tmp_path / "work"
-        (work / ".gewebe").mkdir(parents=True)
-        parquet = work / ".gewebe" / "embeddings.parquet"
-        df = pd.DataFrame(
-            [
-                {
-                    "doc_id": "D1",
+                # 2) Schreibe Minimal-Parquet in isoliertem Arbeitsverzeichnis
+                work = tmp_path / "work"
+                (work / ".gewebe").mkdir(parents=True)
+                parquet = work / ".gewebe" / "embeddings.parquet"
+                df = pd.DataFrame(
+                    [
+                        {
+                            "doc_id": "D1",
+                            "namespace": "ns",
+                            "id": "c1",
+                            "text": "hello world",
+                            "embedding": [1.0, 0.0],
+                        }
+                    ]
+                )
+                # pandas benötigt i.d.R. pyarrow/fastparquet – in diesem Projekt sollte pyarrow verfügbar sein.
+                df.to_parquet(parquet)
+
+                # 3) push_index.py gegen den laufenden Dienst ausführen
+                # Hinweis: wir setzen CWD auf 'work', damit der Default-Pfad funktioniert;
+                # übergeben aber explizit --embeddings zur Sicherheit.
+                script = Path(__file__).parent.parent / "scripts" / "push_index.py"
+                cmd = [
+                    sys.executable,
+                    str(script),
+                    "--embeddings",
+                    str(parquet),
+                    "--endpoint",
+                    f"{base}/index/upsert",
+                ]
+                proc = subprocess.run(
+                    cmd, cwd=work, capture_output=True, text=True, timeout=25
+                )
+                if proc.returncode != 0:
+                    pytest.fail(
+                        f"push_index.py failed: rc={proc.returncode}\n"
+                        f"STDOUT:\n{proc.stdout}\nSTDERR:\n{proc.stderr}"
+                    )
+
+                # 4) Suche absetzen und Treffer prüfen
+                payload = {
+                    "query": "hello",
+                    "k": 5,
                     "namespace": "ns",
-                    "id": "c1",
-                    "text": "hello world",
                     "embedding": [1.0, 0.0],
                 }
-            ]
-        )
-        # pandas benötigt i.d.R. pyarrow/fastparquet – in diesem Projekt sollte pyarrow verfügbar sein.
-        df.to_parquet(parquet)
+                res = _http_json(f"{base}/index/search", payload, timeout=5.0)
+                results = res.get("results", [])
+                assert len(results) == 1
+                assert results[0]["doc_id"] == "D1"
+                assert results[0]["chunk_id"] == "c1"
+                assert results[0]["score"] > 0.0
 
-        # 3) push_index.py gegen den laufenden Dienst ausführen
-        # Hinweis: wir setzen CWD auf 'work', damit der Default-Pfad funktioniert;
-        # übergeben aber explizit --embeddings zur Sicherheit.
-        script = Path(__file__).parent.parent / "scripts" / "push_index.py"
-        cmd = [
-            sys.executable,
-            str(script),
-            "--embeddings",
-            str(parquet),
-            "--endpoint",
-            f"{base}/index/upsert",
-        ]
-        proc = subprocess.run(cmd, cwd=work, capture_output=True, text=True, timeout=25)
-        if proc.returncode != 0:
-            pytest.fail(
-                f"push_index.py failed: rc={proc.returncode}\n"
-                f"STDOUT:\n{proc.stdout}\nSTDERR:\n{proc.stderr}"
-            )
+                raise RuntimeError("cleanup sentinel")
 
-        # 4) Suche absetzen und Treffer prüfen
-        payload = {
-            "query": "hello",
-            "k": 5,
-            "namespace": "ns",
-            "embedding": [1.0, 0.0],
-        }
-        res = _http_json(f"{base}/index/search", payload, timeout=5.0)
-        results = res.get("results", [])
-        assert len(results) == 1
-        assert results[0]["doc_id"] == "D1"
-        assert results[0]["chunk_id"] == "c1"
-        assert results[0]["score"] > 0.0
+    assert server is not None
+    assert server.poll() is not None


### PR DESCRIPTION
## Ziel

Schließt `SEMANTAH-E2E-PORTABILITY-V1-T001`.

- erhält den Produktionsdefault `0.0.0.0:8080`
- ergänzt `INDEXD_BIND_ADDR` als expliziten, validierten Socket-Override
- führt den Push/Search-E2E-Test auf einem freien Loopback-Port aus
- hält Port 8080 unabhängig belegt bzw. lässt einen fremden Besitzer unangetastet
- wartet vor Zugriffen auf `/healthz`
- beweist Prozessbereinigung auch im Ausnahmefall

## Prüfungen

- 108 Python-Unit-Tests bestanden
- Integrationstest bestanden
- Rust-Workspace-Tests bestanden
- `cargo clippy -p indexd --lib --bins -- -D warnings` bestanden
- WGX `smoke`, `guard`, `knowledge` bestanden
- Diff- und Formatprüfung bestanden

## Diff-Bindung

- Base: `b50bd2813b3f146f5cc51bee2ad6887bfb28ce69`
- Head: `b937491bf9a820ac48ca9aa24a1e4db992fdff98`
- Patch SHA-256: `8aa1691d7651bbe01e0ef7a59168e473431dae3ec95bff83de3ba896cf2fa402`
- Artefakt: `/home/alex/iCloud/Drive/halde/semantah-e2e-portability-b937491-20260716.tgz`
- Artefakt SHA-256: `12b7e1ea32258ac6d8009212714edd9c0d2055a22b3d90c3516abdd170348282`

## Getrennter Bestandsbefund

Der umfassende All-Targets-Clippy-Lauf trifft auf einen bereits auf Base vorhandenen Lint in `crates/indexd/tests/migration.rs:46`. Er ist nicht Teil dieses Diffs und wird separat im Bureau registriert.