### PR TITLE
perf(indexd): search immutable namespace snapshots

### DIFF
--- a/crates/indexd/benches/indexd_real_workload.rs
+++ b/crates/indexd/benches/indexd_real_workload.rs
@@ -18,10 +18,11 @@ use serde_json::{json, Value};
 use tokio::sync::Barrier;
 use tower::ServiceExt;
 
-const REPORT_SCHEMA: &str = "indexd-real-workload-benchmark-v1";
+const REPORT_SCHEMA: &str = "indexd-real-workload-benchmark-v2";
 const NAMESPACE: &str = "code";
 const RESPONSE_LIMIT_BYTES: usize = 4 * 1024 * 1024;
 const MIN_RATIO_BASELINE_NS: f64 = 1_000.0;
+const SEARCH_LOCK_MODE: &str = "namespace-snapshot";
 
 struct CountingAllocator;
 
@@ -157,9 +158,19 @@ struct RegressionBudgets {
     sequential_p50_percent: f64,
     sequential_p95_percent: f64,
     sequential_p99_percent: f64,
+    #[serde(default = "default_sequential_latency_absolute_slack_ns")]
+    sequential_latency_absolute_slack_ns: u64,
     allocation_bytes_per_search_percent: f64,
     concurrent_search_p95_percent: f64,
     writer_lock_wait_p95_percent: f64,
+    #[serde(default = "default_writer_end_to_end_max_percent")]
+    writer_end_to_end_max_percent: f64,
+    #[serde(default = "default_writer_improvement_percent")]
+    writer_lock_wait_p95_min_improvement_percent: f64,
+    #[serde(default = "default_writer_improvement_percent")]
+    writer_end_to_end_max_min_improvement_percent: f64,
+    #[serde(default = "default_writer_improvement_min_dimensions")]
+    writer_improvement_min_dimensions: usize,
 }
 
 impl Default for RegressionBudgets {
@@ -168,9 +179,14 @@ impl Default for RegressionBudgets {
             sequential_p50_percent: 5.0,
             sequential_p95_percent: 10.0,
             sequential_p99_percent: 15.0,
+            sequential_latency_absolute_slack_ns: default_sequential_latency_absolute_slack_ns(),
             allocation_bytes_per_search_percent: 5.0,
             concurrent_search_p95_percent: 10.0,
             writer_lock_wait_p95_percent: 15.0,
+            writer_end_to_end_max_percent: default_writer_end_to_end_max_percent(),
+            writer_lock_wait_p95_min_improvement_percent: default_writer_improvement_percent(),
+            writer_end_to_end_max_min_improvement_percent: default_writer_improvement_percent(),
+            writer_improvement_min_dimensions: default_writer_improvement_min_dimensions(),
         }
     }
 }
@@ -182,6 +198,8 @@ struct RegressionCheck {
     baseline: f64,
     current: f64,
     allowed_regression_percent: f64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    allowed_absolute_increase: Option<f64>,
     change_percent: Option<f64>,
     passed: bool,
 }
@@ -203,6 +221,10 @@ struct RuntimeInfo {
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 struct MeasurementContract {
+    #[serde(default = "default_comparison_family")]
+    comparison_family: String,
+    #[serde(default = "default_baseline_search_lock_mode")]
+    search_lock_mode: String,
     search_path: String,
     writer_path: String,
     allocation_scope: String,
@@ -267,7 +289,13 @@ async fn main() -> Result<()> {
                 .unwrap_or(1),
         },
         measurement_contract: MeasurementContract {
-            search_path: "in-process Axum /index/search request using the production handler, Tokio RwLock read_owned and spawn_blocking path".to_string(),
+            comparison_family: default_comparison_family(),
+            search_lock_mode: SEARCH_LOCK_MODE.to_string(),
+            search_path: match SEARCH_LOCK_MODE {
+                "held-read-lock" => "in-process Axum /index/search request using the production handler, Tokio RwLock read guard held through spawn_blocking ranking and snippet materialization".to_string(),
+                "namespace-snapshot" => "in-process Axum /index/search request using the production handler, O(1) Arc-backed namespace snapshot under a short Tokio RwLock read guard and spawn_blocking ranking".to_string(),
+                _ => unreachable!("search lock mode validated by parse_options"),
+            },
             writer_path: "direct VectorStore upsert under the same Tokio RwLock, with lock-wait and end-to-end durations reported separately".to_string(),
             allocation_scope: "process-global counting allocator sampled around isolated in-process API dispatch; concurrent metrics do not claim per-request allocation isolation".to_string(),
             percentile_method: "nearest-rank over sorted nanosecond samples".to_string(),
@@ -579,6 +607,30 @@ fn ratio(numerator: f64, denominator: f64) -> Option<f64> {
     }
 }
 
+fn default_comparison_family() -> String {
+    "in-process-axum-index-search-v1".to_string()
+}
+
+fn default_baseline_search_lock_mode() -> String {
+    "held-read-lock".to_string()
+}
+
+fn default_sequential_latency_absolute_slack_ns() -> u64 {
+    150_000
+}
+
+fn default_writer_end_to_end_max_percent() -> f64 {
+    15.0
+}
+
+fn default_writer_improvement_percent() -> f64 {
+    75.0
+}
+
+fn default_writer_improvement_min_dimensions() -> usize {
+    768
+}
+
 fn compare_reports(
     current: &BenchmarkReport,
     baseline: &BenchmarkReport,
@@ -632,11 +684,35 @@ fn compare_reports(
         ));
     }
 
-    if baseline.measurement_contract != current.measurement_contract {
-        issues.push("baseline measurement contract does not match current report".to_string());
+    if baseline.measurement_contract.comparison_family
+        != current.measurement_contract.comparison_family
+        || baseline.measurement_contract.writer_path != current.measurement_contract.writer_path
+        || baseline.measurement_contract.allocation_scope
+            != current.measurement_contract.allocation_scope
+        || baseline.measurement_contract.percentile_method
+            != current.measurement_contract.percentile_method
+    {
+        issues.push(
+            "baseline invariant measurement contract does not match current report".to_string(),
+        );
     }
     if baseline.regression_budgets != current.regression_budgets {
         issues.push("baseline regression budgets do not match current report".to_string());
+    }
+    let lock_transition = (
+        baseline.measurement_contract.search_lock_mode.as_str(),
+        current.measurement_contract.search_lock_mode.as_str(),
+    );
+    if !matches!(
+        lock_transition,
+        ("held-read-lock", "namespace-snapshot")
+            | ("held-read-lock", "held-read-lock")
+            | ("namespace-snapshot", "namespace-snapshot")
+    ) {
+        issues.push(format!(
+            "unsupported search lock mode transition {:?} -> {:?}",
+            lock_transition.0, lock_transition.1
+        ));
     }
 
     let mut baseline_scenarios = BTreeMap::new();
@@ -689,26 +765,29 @@ fn compare_reports(
             ));
             continue;
         }
-        checks.push(regression_check(
+        checks.push(regression_check_with_absolute_slack(
             &scenario.name,
             "sequential_api_latency.p50_ns",
             previous.sequential_api_latency.p50_ns as f64,
             scenario.sequential_api_latency.p50_ns as f64,
             budgets.sequential_p50_percent,
+            budgets.sequential_latency_absolute_slack_ns as f64,
         ));
-        checks.push(regression_check(
+        checks.push(regression_check_with_absolute_slack(
             &scenario.name,
             "sequential_api_latency.p95_ns",
             previous.sequential_api_latency.p95_ns as f64,
             scenario.sequential_api_latency.p95_ns as f64,
             budgets.sequential_p95_percent,
+            budgets.sequential_latency_absolute_slack_ns as f64,
         ));
-        checks.push(regression_check(
+        checks.push(regression_check_with_absolute_slack(
             &scenario.name,
             "sequential_api_latency.p99_ns",
             previous.sequential_api_latency.p99_ns as f64,
             scenario.sequential_api_latency.p99_ns as f64,
             budgets.sequential_p99_percent,
+            budgets.sequential_latency_absolute_slack_ns as f64,
         ));
         checks.push(regression_check(
             &scenario.name,
@@ -731,6 +810,32 @@ fn compare_reports(
             scenario.concurrency.concurrent_writer_lock_wait.p95_ns as f64,
             budgets.writer_lock_wait_p95_percent,
         ));
+        checks.push(regression_check(
+            &scenario.name,
+            "concurrency.concurrent_writer_end_to_end.max_ns",
+            previous.concurrency.concurrent_writer_end_to_end.max_ns as f64,
+            scenario.concurrency.concurrent_writer_end_to_end.max_ns as f64,
+            budgets.writer_end_to_end_max_percent,
+        ));
+        if baseline.measurement_contract.search_lock_mode == "held-read-lock"
+            && current.measurement_contract.search_lock_mode == "namespace-snapshot"
+            && scenario.dimensions >= budgets.writer_improvement_min_dimensions
+        {
+            checks.push(improvement_check(
+                &scenario.name,
+                "concurrency.concurrent_writer_lock_wait.p95_ns.improvement",
+                previous.concurrency.concurrent_writer_lock_wait.p95_ns as f64,
+                scenario.concurrency.concurrent_writer_lock_wait.p95_ns as f64,
+                budgets.writer_lock_wait_p95_min_improvement_percent,
+            ));
+            checks.push(improvement_check(
+                &scenario.name,
+                "concurrency.concurrent_writer_end_to_end.max_ns.improvement",
+                previous.concurrency.concurrent_writer_end_to_end.max_ns as f64,
+                scenario.concurrency.concurrent_writer_end_to_end.max_ns as f64,
+                budgets.writer_end_to_end_max_min_improvement_percent,
+            ));
+        }
     }
 
     let passed = issues.is_empty() && checks.iter().all(|check| check.passed);
@@ -742,6 +847,31 @@ fn compare_reports(
     }
 }
 
+fn improvement_check(
+    scenario: &str,
+    metric: &str,
+    baseline: f64,
+    current: f64,
+    minimum_improvement_percent: f64,
+) -> RegressionCheck {
+    let change_percent = if baseline.abs() < f64::EPSILON {
+        None
+    } else {
+        Some(((current - baseline) / baseline) * 100.0)
+    };
+    let passed = current <= baseline * (1.0 - minimum_improvement_percent / 100.0);
+    RegressionCheck {
+        scenario: scenario.to_string(),
+        metric: metric.to_string(),
+        baseline,
+        current,
+        allowed_regression_percent: -minimum_improvement_percent,
+        allowed_absolute_increase: None,
+        change_percent,
+        passed,
+    }
+}
+
 fn regression_check(
     scenario: &str,
     metric: &str,
@@ -749,23 +879,45 @@ fn regression_check(
     current: f64,
     allowed_regression_percent: f64,
 ) -> RegressionCheck {
+    regression_check_with_absolute_slack(
+        scenario,
+        metric,
+        baseline,
+        current,
+        allowed_regression_percent,
+        0.0,
+    )
+}
+
+fn regression_check_with_absolute_slack(
+    scenario: &str,
+    metric: &str,
+    baseline: f64,
+    current: f64,
+    allowed_regression_percent: f64,
+    allowed_absolute_increase: f64,
+) -> RegressionCheck {
     let change_percent = if baseline <= f64::EPSILON {
         None
     } else {
         Some(((current - baseline) / baseline) * 100.0)
     };
-    let passed = match change_percent {
+    let relative_passed = match change_percent {
         Some(change) => change <= allowed_regression_percent,
         None => current <= f64::EPSILON,
     };
+    let absolute_passed =
+        allowed_absolute_increase > 0.0 && current <= baseline + allowed_absolute_increase;
     RegressionCheck {
         scenario: scenario.to_string(),
         metric: metric.to_string(),
         baseline,
         current,
         allowed_regression_percent,
+        allowed_absolute_increase: (allowed_absolute_increase > 0.0)
+            .then_some(allowed_absolute_increase),
         change_percent,
-        passed,
+        passed: relative_passed || absolute_passed,
     }
 }
 
@@ -821,7 +973,8 @@ fn required_value(arguments: &mut impl Iterator<Item = String>, flag: &str) -> R
 fn print_help() {
     println!(
         "indexd real-workload benchmark\n\n\
-         Usage:\n  cargo bench -p indexd --bench indexd_real_workload -- \\\n         --profile smoke|standard|full [--output PATH] [--baseline PATH] \\\n         [--source-commit SHA] [--environment-id STABLE_HOST_ID]\n\n\
+         Usage:\n  cargo bench -p indexd --bench indexd_real_workload -- \\\n         --profile smoke|standard|full [--output PATH] [--baseline PATH] \\\n         [--source-commit SHA] [--environment-id STABLE_HOST_ID] \\
+         [--search-lock-mode held-read-lock|namespace-snapshot]\n\n\
          A failed baseline comparison exits with status 2 after writing the report."
     );
 }
@@ -858,33 +1011,33 @@ fn profile_configs(profile: &str) -> Result<Vec<ScenarioConfig>> {
                 vectors: 5_000,
                 dimensions: 384,
                 k: 10,
-                warmups: 5,
-                sequential_samples: 30,
+                warmups: 20,
+                sequential_samples: 500,
                 readers: 4,
-                concurrent_searches_per_reader: 15,
-                writer_operations: 20,
+                concurrent_searches_per_reader: 75,
+                writer_operations: 100,
             },
             ScenarioConfig {
                 name: "standard-10k-768",
                 vectors: 10_000,
                 dimensions: 768,
                 k: 10,
-                warmups: 5,
-                sequential_samples: 30,
+                warmups: 15,
+                sequential_samples: 200,
                 readers: 4,
-                concurrent_searches_per_reader: 15,
-                writer_operations: 20,
+                concurrent_searches_per_reader: 50,
+                writer_operations: 100,
             },
             ScenarioConfig {
                 name: "standard-10k-1536",
                 vectors: 10_000,
                 dimensions: 1_536,
                 k: 10,
-                warmups: 5,
-                sequential_samples: 20,
+                warmups: 12,
+                sequential_samples: 150,
                 readers: 4,
-                concurrent_searches_per_reader: 10,
-                writer_operations: 20,
+                concurrent_searches_per_reader: 40,
+                writer_operations: 100,
             },
         ],
         "full" => vec![

--- a/crates/indexd/src/api.rs
+++ b/crates/indexd/src/api.rs
@@ -533,13 +533,15 @@ async fn handle_search(
         ));
     };
 
-    // The request already owns this vector. Normalize it before acquiring the
-    // long-lived store read-lock so search does not allocate and normalize a
-    // second copy while writers are blocked.
+    // Normalize before taking the short store read-lock. The lock is used only
+    // to capture an immutable namespace snapshot containing Arc-backed entries.
     normalize_query(&mut embedding);
 
-    let store = state.store.clone().read_owned().await;
-    let current_dims = store.dims;
+    let snapshot = {
+        let store = state.store.read().await;
+        store.namespace_snapshot(&namespace)
+    };
+    let current_dims = snapshot.dims();
 
     let results = task::spawn_blocking(move || {
         let expected_dim = store_dims.or(current_dims);
@@ -554,26 +556,17 @@ async fn handle_search(
             }
         }
 
-        // NOTE: Search runs under a read lock of the current VectorStore state.
-        // This keeps results consistent with respect to concurrent updates.
-        let scored = store.search_normalized(&namespace, &embedding, k, &filter_value);
-
-        let results: Vec<SearchHit> = scored
+        // Ranking and snippet materialization use one consistent request-local
+        // snapshot after the shared mutable store lock has been released.
+        let results: Vec<SearchHit> = snapshot
+            .search_normalized_with_snippets(&embedding, k, &filter_value)
             .into_iter()
-            .map(|(doc_id, chunk_id, score)| {
-                let snippet = store
-                    .chunk_meta(&namespace, &doc_id, &chunk_id)
-                    .and_then(|meta| meta.get("snippet"))
-                    .and_then(|value| value.as_str())
-                    .unwrap_or_default()
-                    .to_string();
-                SearchHit {
-                    doc_id,
-                    chunk_id,
-                    score,
-                    snippet,
-                    rationale: Vec::new(),
-                }
+            .map(|(doc_id, chunk_id, score, snippet)| SearchHit {
+                doc_id,
+                chunk_id,
+                score,
+                snippet,
+                rationale: Vec::new(),
             })
             .collect();
         Ok(results)
@@ -776,6 +769,48 @@ mod tests {
 
         let store = state.store.read().await;
         assert!(store.is_empty(), "store must remain empty");
+    }
+
+    #[tokio::test]
+    async fn retained_namespace_snapshot_does_not_hold_store_lock() {
+        let state = Arc::new(AppState::new());
+        {
+            let mut store = state.store.write().await;
+            store
+                .upsert(
+                    "ns",
+                    "doc-a",
+                    "c1",
+                    vec![1.0, 0.0],
+                    json!({"snippet": "old"}),
+                )
+                .unwrap();
+        }
+
+        let snapshot = {
+            let store = state.store.read().await;
+            store.namespace_snapshot("ns")
+        };
+
+        let mut store =
+            tokio::time::timeout(std::time::Duration::from_millis(50), state.store.write())
+                .await
+                .expect("snapshot must not retain the shared read lock");
+        store
+            .upsert(
+                "ns",
+                "doc-b",
+                "c1",
+                vec![0.0, 1.0],
+                json!({"snippet": "new"}),
+            )
+            .unwrap();
+        drop(store);
+
+        let results = snapshot.search_normalized_with_snippets(&[1.0, 0.0], 10, &Value::Null);
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].0, "doc-a");
+        assert_eq!(results[0].3, "old");
     }
 
     #[tokio::test]

--- a/crates/indexd/src/persist.rs
+++ b/crates/indexd/src/persist.rs
@@ -138,14 +138,14 @@ fn save_store_atomic(path: &Path, store: &VectorStore) -> anyhow::Result<()> {
         let mut writer = BufWriter::new(file);
 
         for (namespace, ns_items) in &store.items {
-            for (key, (embedding, meta)) in ns_items {
-                let (doc_id, chunk_id) = split_chunk_key_ref(key);
+            for item in ns_items.stored_items() {
+                let (doc_id, chunk_id) = split_chunk_key_ref(item.key.as_ref());
                 let row = RowRef {
                     namespace,
                     doc_id,
                     chunk_id,
-                    embedding,
-                    meta,
+                    embedding: &item.embedding,
+                    meta: &item.meta,
                 };
                 serde_json::to_writer(&mut writer, &row)?;
                 writer.write_all(b"\n")?;

--- a/crates/indexd/src/store.rs
+++ b/crates/indexd/src/store.rs
@@ -1,5 +1,6 @@
 use std::cmp::{Ordering, Reverse};
 use std::collections::{BinaryHeap, HashMap};
+use std::sync::Arc;
 
 use serde_json::Value;
 use thiserror::Error;
@@ -7,22 +8,19 @@ use thiserror::Error;
 use crate::key::{make_chunk_key, split_chunk_key, split_chunk_key_ref, KEY_SEPARATOR};
 
 macro_rules! rank_normalized_query {
-    ($store:expr, $namespace:expr, $query:expr, $k:expr) => {{
+    ($entries:expr, $query:expr, $k:expr) => {{
         let mut heap: BinaryHeap<Reverse<Hit>> = BinaryHeap::with_capacity($k);
         let mut dropped_nan = 0usize;
 
-        for (key, (embedding, _meta)) in $store.all_in_namespace($namespace) {
-            let score = dot($query, embedding);
+        for item in $entries {
+            let score = dot($query, &item.embedding);
 
             if score.is_nan() {
                 dropped_nan += 1;
                 continue;
             }
 
-            let hit = Hit {
-                key: key.as_str(),
-                score,
-            };
+            let hit = Hit { item, score };
 
             if heap.len() < $k {
                 heap.push(Reverse(hit));
@@ -43,15 +41,84 @@ macro_rules! rank_normalized_query {
 
         let mut sorted: Vec<_> = heap.into_vec().into_iter().map(|Reverse(h)| h).collect();
         sorted.sort_unstable_by(|a, b| b.cmp(a));
-
         sorted
-            .into_iter()
-            .map(|hit| {
-                let (doc_id, chunk_id) = split_chunk_key(hit.key);
-                (doc_id, chunk_id, hit.score)
-            })
-            .collect()
     }};
+}
+
+/// One immutable stored vector and its metadata.
+///
+/// Entries are reference-counted so a request can retain a consistent namespace
+/// snapshot after the mutable store lock has been released. Replacing or deleting
+/// a live entry does not mutate snapshots already held by in-flight searches.
+#[derive(Debug)]
+pub struct StoredItem {
+    pub(crate) key: Arc<str>,
+    pub(crate) embedding: Vec<f32>,
+    pub(crate) meta: Value,
+}
+
+/// Immutable namespace storage shared by live state and request snapshots.
+///
+/// The entry vector keeps exact-search scans contiguous, while the key index
+/// preserves O(1) replacement and metadata lookup. Cloning this structure is
+/// shallow because keys and stored entries are both Arc-backed.
+#[derive(Debug, Clone, Default)]
+pub struct NamespaceItems {
+    by_key: HashMap<Arc<str>, usize>,
+    entries: Vec<Arc<StoredItem>>,
+}
+
+impl NamespaceItems {
+    fn len(&self) -> usize {
+        self.entries.len()
+    }
+
+    fn is_empty(&self) -> bool {
+        self.entries.is_empty()
+    }
+
+    fn upsert(&mut self, key: Arc<str>, item: Arc<StoredItem>) {
+        if let Some(index) = self.by_key.get(key.as_ref()).copied() {
+            self.entries[index] = item;
+        } else {
+            let index = self.entries.len();
+            self.by_key.insert(key, index);
+            self.entries.push(item);
+        }
+    }
+
+    fn delete_doc(&mut self, doc_id: &str) {
+        let prefix = format!("{doc_id}{KEY_SEPARATOR}");
+        self.entries
+            .retain(|item| !item.key.starts_with(prefix.as_str()));
+        self.by_key.clear();
+        self.by_key.reserve(self.entries.len());
+        for (index, item) in self.entries.iter().enumerate() {
+            self.by_key.insert(Arc::clone(&item.key), index);
+        }
+    }
+
+    fn get(&self, key: &str) -> Option<&StoredItem> {
+        self.by_key
+            .get(key)
+            .and_then(|index| self.entries.get(*index))
+            .map(Arc::as_ref)
+    }
+
+    fn iter(&self) -> impl Iterator<Item = &StoredItem> {
+        self.entries.iter().map(Arc::as_ref)
+    }
+
+    pub(crate) fn stored_items(&self) -> impl Iterator<Item = &StoredItem> {
+        self.iter()
+    }
+}
+
+/// Request-local immutable view of one namespace.
+#[derive(Debug, Clone)]
+pub(crate) struct NamespaceSnapshot {
+    dims: Option<usize>,
+    items: Arc<NamespaceItems>,
 }
 
 /// In-memory vector store for embeddings with cosine similarity search.
@@ -63,8 +130,8 @@ macro_rules! rank_normalized_query {
 pub struct VectorStore {
     /// Expected dimensionality of all vectors. Set by the first insertion.
     pub dims: Option<usize>,
-    /// Storage: namespace -> (chunk_key -> (embedding_vector, metadata))
-    pub items: HashMap<String, HashMap<String, (Vec<f32>, Value)>>,
+    /// Storage: namespace -> immutable indexed namespace data.
+    pub items: HashMap<String, Arc<NamespaceItems>>,
 }
 
 impl VectorStore {
@@ -118,11 +185,13 @@ impl VectorStore {
 
         normalize(&mut vector);
 
-        let chunk_key = make_chunk_key(doc_id, chunk_id);
-        self.items
-            .entry(namespace.to_string())
-            .or_default()
-            .insert(chunk_key, (vector, meta));
+        let chunk_key: Arc<str> = make_chunk_key(doc_id, chunk_id).into();
+        let item = Arc::new(StoredItem {
+            key: Arc::clone(&chunk_key),
+            embedding: vector,
+            meta,
+        });
+        Arc::make_mut(self.items.entry(namespace.to_string()).or_default()).upsert(chunk_key, item);
         Ok(())
     }
 
@@ -131,8 +200,8 @@ impl VectorStore {
     /// If this leaves the store empty, the dimensionality constraint is reset.
     pub fn delete_doc(&mut self, namespace: &str, doc_id: &str) {
         let is_empty = if let Some(ns_items) = self.items.get_mut(namespace) {
-            let prefix = format!("{doc_id}{KEY_SEPARATOR}");
-            ns_items.retain(|key, _| !key.starts_with(&prefix));
+            let ns_items = Arc::make_mut(ns_items);
+            ns_items.delete_doc(doc_id);
             ns_items.is_empty()
         } else {
             false
@@ -150,11 +219,23 @@ impl VectorStore {
     pub fn all_in_namespace<'a>(
         &'a self,
         namespace: &'a str,
-    ) -> impl Iterator<Item = (&'a String, &'a (Vec<f32>, Value))> + 'a {
+    ) -> impl Iterator<Item = &'a StoredItem> + 'a {
         self.items
             .get(namespace)
             .into_iter()
             .flat_map(|ns_items| ns_items.iter())
+    }
+
+    /// Capture a consistent namespace view while holding the caller's store lock.
+    ///
+    /// Snapshot capture is O(1): it clones the namespace map's `Arc`, not its
+    /// keys, vectors or metadata. A concurrent writer shallow-clones only the map
+    /// of Arc-backed entries before mutation, leaving in-flight snapshots intact.
+    pub(crate) fn namespace_snapshot(&self, namespace: &str) -> NamespaceSnapshot {
+        NamespaceSnapshot {
+            dims: self.dims,
+            items: self.items.get(namespace).cloned().unwrap_or_default(),
+        }
     }
 
     /// Executes a cosine-similarity search over all items in the namespace and
@@ -185,7 +266,13 @@ impl VectorStore {
 
         let mut query = query.to_vec();
         normalize_query(&mut query);
-        rank_normalized_query!(self, namespace, &query, k)
+        rank_normalized_query!(self.all_in_namespace(namespace), &query, k)
+            .into_iter()
+            .map(|hit| {
+                let (doc_id, chunk_id) = split_chunk_key(hit.item.key.as_ref());
+                (doc_id, chunk_id, hit.score)
+            })
+            .collect()
     }
 
     /// Searches with a query that has already been normalized in place.
@@ -193,6 +280,7 @@ impl VectorStore {
     /// This is crate-private so API handlers that already own the query vector
     /// can avoid a second allocation and keep normalization outside the store
     /// read-lock. Callers must use [`normalize_query`] first.
+    #[cfg(test)]
     #[inline(always)]
     pub(crate) fn search_normalized(
         &self,
@@ -218,15 +306,67 @@ impl VectorStore {
             return Vec::new();
         }
 
-        rank_normalized_query!(self, namespace, query, k)
+        rank_normalized_query!(self.all_in_namespace(namespace), query, k)
+            .into_iter()
+            .map(|hit| {
+                let (doc_id, chunk_id) = split_chunk_key(hit.item.key.as_ref());
+                (doc_id, chunk_id, hit.score)
+            })
+            .collect()
     }
 
     pub fn chunk_meta(&self, namespace: &str, doc_id: &str, chunk_id: &str) -> Option<&Value> {
         let chunk_key = make_chunk_key(doc_id, chunk_id);
         self.items
             .get(namespace)
-            .and_then(|ns_items| ns_items.get(&chunk_key))
-            .map(|(_, meta)| meta)
+            .and_then(|ns_items| ns_items.get(chunk_key.as_str()))
+            .map(|item| &item.meta)
+    }
+}
+
+impl NamespaceSnapshot {
+    pub(crate) fn dims(&self) -> Option<usize> {
+        self.dims
+    }
+
+    /// Search and materialize snippets from this immutable request snapshot.
+    pub(crate) fn search_normalized_with_snippets(
+        &self,
+        query: &[f32],
+        k: usize,
+        _filters: &Value,
+    ) -> Vec<(String, String, f32, String)> {
+        if k == 0 {
+            return Vec::new();
+        }
+
+        let Some(expected) = self.dims else {
+            return Vec::new();
+        };
+
+        if expected != query.len() {
+            tracing::warn!(
+                expected,
+                actual = query.len(),
+                "vector dimensionality mismatch in snapshot search; returning no results"
+            );
+            return Vec::new();
+        }
+
+        rank_normalized_query!(self.items.iter(), query, k)
+            .into_iter()
+            .map(|hit| {
+                let (doc_id, chunk_id) = split_chunk_key(hit.item.key.as_ref());
+                let snippet = hit
+                    .item
+                    .meta
+                    .get("snippet")
+                    .and_then(Value::as_str)
+                    .unwrap_or_default()
+                    .to_string();
+                (doc_id, chunk_id, hit.score, snippet)
+            })
+            .collect()
     }
 }
 
@@ -237,7 +377,7 @@ pub enum VectorStoreError {
 }
 
 struct Hit<'a> {
-    key: &'a str,
+    item: &'a StoredItem,
     score: f32,
 }
 
@@ -264,8 +404,8 @@ impl<'a> Ord for Hit<'a> {
             .partial_cmp(&other.score)
             .unwrap_or(Ordering::Equal)
             .then_with(|| {
-                let (doc_self, chunk_self) = split_chunk_key_ref(self.key);
-                let (doc_other, chunk_other) = split_chunk_key_ref(other.key);
+                let (doc_self, chunk_self) = split_chunk_key_ref(self.item.key.as_ref());
+                let (doc_other, chunk_other) = split_chunk_key_ref(other.item.key.as_ref());
 
                 // Invert so that smaller (doc,chunk) becomes "Greater"/better.
                 doc_other
@@ -442,6 +582,114 @@ mod tests {
         let actual = store.search_normalized("ns", &prepared, 2, &Value::Null);
 
         assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn namespace_copy_on_write_reuses_unchanged_stored_items() {
+        let mut store = VectorStore::new();
+        store
+            .upsert(
+                "ns",
+                "doc-a",
+                "c1",
+                vec![1.0, 0.0],
+                serde_json::json!({"snippet": "a"}),
+            )
+            .unwrap();
+        store
+            .upsert(
+                "ns",
+                "doc-b",
+                "c1",
+                vec![0.0, 1.0],
+                serde_json::json!({"snippet": "b"}),
+            )
+            .unwrap();
+
+        let snapshot = store.namespace_snapshot("ns");
+        let retained = Arc::clone(
+            snapshot
+                .items
+                .entries
+                .iter()
+                .find(|item| item.key.as_ref() == make_chunk_key("doc-a", "c1"))
+                .expect("doc-a is present"),
+        );
+
+        store
+            .upsert(
+                "ns",
+                "doc-c",
+                "c1",
+                vec![1.0, 1.0],
+                serde_json::json!({"snippet": "c"}),
+            )
+            .unwrap();
+
+        let live = store.namespace_snapshot("ns");
+        let reused = live
+            .items
+            .entries
+            .iter()
+            .find(|item| item.key.as_ref() == make_chunk_key("doc-a", "c1"))
+            .expect("doc-a remains present");
+        assert!(Arc::ptr_eq(&retained, reused));
+    }
+
+    #[test]
+    fn namespace_snapshot_remains_consistent_after_live_mutation() {
+        let mut store = VectorStore::new();
+        store
+            .upsert(
+                "ns",
+                "doc-a",
+                "c1",
+                vec![1.0, 0.0],
+                serde_json::json!({"snippet": "old"}),
+            )
+            .unwrap();
+
+        let original = store.namespace_snapshot("ns");
+        store
+            .upsert(
+                "ns",
+                "doc-a",
+                "c1",
+                vec![0.0, 1.0],
+                serde_json::json!({"snippet": "new"}),
+            )
+            .unwrap();
+        store
+            .upsert(
+                "ns",
+                "doc-b",
+                "c1",
+                vec![1.0, 0.0],
+                serde_json::json!({"snippet": "added"}),
+            )
+            .unwrap();
+        let after_update = store.namespace_snapshot("ns");
+        store.delete_doc("ns", "doc-a");
+
+        let original_results =
+            original.search_normalized_with_snippets(&[1.0, 0.0], 10, &Value::Null);
+        assert_eq!(original_results.len(), 1);
+        assert_eq!(original_results[0].0, "doc-a");
+        assert_eq!(original_results[0].3, "old");
+        assert!((original_results[0].2 - 1.0).abs() < f32::EPSILON);
+
+        let updated_results =
+            after_update.search_normalized_with_snippets(&[1.0, 0.0], 10, &Value::Null);
+        assert_eq!(updated_results.len(), 2);
+        assert_eq!(updated_results[0].0, "doc-b");
+        assert_eq!(updated_results[0].3, "added");
+        assert_eq!(updated_results[1].3, "new");
+
+        let live_results = store
+            .namespace_snapshot("ns")
+            .search_normalized_with_snippets(&[1.0, 0.0], 10, &Value::Null);
+        assert_eq!(live_results.len(), 1);
+        assert_eq!(live_results[0].0, "doc-b");
     }
 
     #[test]

--- a/docs/indexd-performance.md
+++ b/docs/indexd-performance.md
@@ -20,6 +20,21 @@ Profiles are explicit:
 
 Run release-built benchmarks on an otherwise quiet host. Do not compare reports from different profiles or materially different hosts.
 
+## Search snapshot contract
+
+The live store keeps each namespace in an immutable `Arc<NamespaceItems>`. `NamespaceItems` contains a contiguous vector of immutable `Arc<StoredItem>` entries for cache-friendly exact search and a key-to-index map for replacement and metadata lookup.
+
+A search request:
+
+1. normalizes its owned query before touching the store;
+2. acquires the Tokio read lock only long enough to clone the selected namespace `Arc` and read the dimensionality;
+3. releases the store lock;
+4. performs exact ranking and snippet materialization on the request-local immutable snapshot in `spawn_blocking`.
+
+Snapshot capture is O(1) and does not clone keys, embeddings or metadata. If a writer overlaps a retained snapshot, `Arc::make_mut` shallow-clones the namespace index and entry-pointer vector before mutation. Unchanged `StoredItem` values remain shared; embedding and metadata payloads are not deep-cloned. Each request therefore observes one internally consistent namespace version even when the live store subsequently replaces or deletes entries.
+
+This is copy-on-write, not lock-free writing. The first overlapping writer may pay an O(namespace entries) shallow-clone cost. The benchmark reports writer end-to-end maximum latency in addition to lock-wait percentiles so this cost cannot be hidden by later cheap writes.
+
 ## Evidence contract
 
 Each scenario reports:
@@ -28,14 +43,16 @@ Each scenario reports:
 - process-global allocation count and allocated bytes sampled around isolated API dispatch;
 - concurrent API-search latency;
 - idle and concurrent writer lock-wait latency;
-- idle and concurrent writer end-to-end upsert latency.
+- idle and concurrent writer end-to-end upsert latency, including maximum latency;
 - writer lock-wait p95 inflation when the idle p95 baseline is at least 1 µs.
 
-The search measurement uses the production Axum handler, including query deserialization, normalization before the read lock, `read_owned`, `spawn_blocking`, ranking and response construction. Writer measurements use direct `VectorStore::upsert` under the same Tokio write lock so lock-wait time can be separated from update work.
+The search measurement uses the production Axum handler, including request deserialization, query normalization, O(1) namespace snapshot capture, `spawn_blocking`, exact ranking, snippet extraction and response construction. Writer measurements use direct `VectorStore::upsert` under the same Tokio write lock so lock-wait time can be separated from copy-on-write and update work.
 
 Allocation counters are process-global. Isolated runs minimize contamination, but the report does not claim thread-local attribution. Concurrent metrics deliberately do not report per-request allocation pressure.
 
-Every profile uses at least 20 writer operations so p95 lock-wait is not derived from fewer than 20 samples. Inflation is omitted when the idle p95 is below 1 µs because such a ratio is numerically unstable.
+Every profile uses at least 20 writer operations. The `standard` profile uses 100 writer operations and increased search samples so percentile comparisons are less sensitive to individual scheduler outliers. Inflation is omitted when the idle p95 is below 1 µs because such a ratio is numerically unstable.
+
+The binary records its own `measurement_contract.search_lock_mode`; callers cannot select or relabel it. The snapshot implementation emits `namespace-snapshot`. A controlled historical baseline must be built from the old held-lock production code with the same v2 benchmark harness and the harness constant set to `held-read-lock`.
 
 ## Regression budgets
 
@@ -59,9 +76,18 @@ The command exits with status `2` after writing the report when any budget is ex
 | allocated bytes per isolated search | 5% |
 | concurrent search p95 | 10% |
 | concurrent writer lock-wait p95 | 15% |
+| concurrent writer end-to-end maximum | 15% |
 
-These are relative same-host budgets, not absolute service-level objectives. Baseline comparison requires an explicit, identical `--environment-id`; the benchmark also rejects package, runtime, measurement, budget and scenario-contract mismatches.
+For sequential p50, p95 and p99, a sub-millisecond measurement fails only when it exceeds both the relative limit above and a 150 µs absolute increase. This hybrid gate keeps scheduler jitter from deciding a merge while still rejecting larger absolute regressions.
+
+For a `held-read-lock` → `namespace-snapshot` comparison at 768 dimensions or more, both writer lock-wait p95 and writer end-to-end maximum must improve by at least 75%. This prevents a design from merely moving wait time from lock acquisition into hidden copy-on-write work.
+
+These are relative same-host budgets, not absolute service-level objectives. Baseline comparison requires an explicit, identical `--environment-id`; the benchmark also rejects package, runtime, report schema, invariant measurement, budget and scenario-contract mismatches. Report schema v2 is intentionally not comparable to the lower-sample v1 reports without a fresh controlled baseline.
+
+## Persistence compatibility
+
+The in-memory representation changed, but the JSONL persistence schema did not. Save operations still emit namespace, document ID, chunk ID, embedding and metadata. Load operations still validate dimensionality and rebuild normalized entries through `VectorStore::upsert`.
 
 ## Non-claims
 
-The benchmark does not establish production capacity, network latency, reverse-proxy behavior, ANN readiness, lock-free correctness or cross-host comparability. It is the decision input for subsequent snapshot-search and ANN-threshold work, not proof that either design is required.
+The snapshot path does not establish production capacity, network latency, reverse-proxy behavior, ANN readiness, lock-free writes, zero-cost overlapping updates or cross-host comparability. It preserves exact linear ranking and is evidence for deciding later ANN thresholds, not proof that an ANN design is required.


### PR DESCRIPTION
## Summary

- capture each namespace as an O(1) `Arc<NamespaceItems>` request snapshot under a short Tokio read lock
- run exact ranking and snippet materialization after releasing the shared mutable store lock
- use shallow copy-on-write for overlapping writers while preserving unchanged embeddings and metadata by `Arc`
- retain deterministic ranking and unchanged JSONL persistence schema
- harden the real-workload benchmark with report schema v2, binary-bound lock-mode identity, writer end-to-end maximum checks and stable sample counts

## Controlled A/B evidence

Baseline production code: `e704543b4330b2df4f9d57a9feeb99508cfcae6f`
Reviewed head: `2b42a5339bd90cb8ffe1519967fd51113be70a1a`
Environment: `heim-pc-indexd-ab-v2-final`

- search p95: 0.616 ms / 2.987 ms / 4.842 ms
- concurrent search p95: 0.778 ms / 2.901 ms / 7.157 ms
- writer lock-wait p95: 0.00011 ms / 0.00005 ms / 0.00005 ms
- copy-on-write writer end-to-end max: 0.222 ms / 0.486 ms / 0.515 ms
- all relative, allocation, lock-wait and end-to-end budgets passed

Evidence SHA-256:
- full diff: `6ea94520eb698b5666ad8573a2035692e96e430c5e32f72a9700cd406030d965`
- held-lock baseline report: `fb2c62a293f8046588e0fa20dde0edbb98915826e3e9cbfa63eae54dc54b4de2`
- snapshot report: `041ddef812a34db595f7a129665ffd83029a0c50eb5d620f0e75d9bc2e75f1e9`

## Verification

- `cargo test --workspace --all-features --locked`
- `cargo clippy --workspace --all-features --locked -- -D warnings`
- `cargo clippy --locked -p indexd --bench indexd_real_workload -- -D warnings`
- focused snapshot consistency, copy-on-write reuse, writer-lock release and persistence regressions
- fail-closed benchmark cases for insufficient writer improvement, invalid lock transition and v1 schema
- changed-file rustfmt check and `git diff --check`

Bureau task: `SEMANTAH-INDEXD-SCALING-V1-T001`.