### PR TITLE
fix(indexd): align benchmark help with parser

### DIFF
--- a/crates/indexd/benches/indexd_real_workload.rs
+++ b/crates/indexd/benches/indexd_real_workload.rs
@@ -294,7 +294,7 @@ async fn main() -> Result<()> {
             search_path: match SEARCH_LOCK_MODE {
                 "held-read-lock" => "in-process Axum /index/search request using the production handler, Tokio RwLock read guard held through spawn_blocking ranking and snippet materialization".to_string(),
                 "namespace-snapshot" => "in-process Axum /index/search request using the production handler, O(1) Arc-backed namespace snapshot under a short Tokio RwLock read guard and spawn_blocking ranking".to_string(),
-                _ => unreachable!("search lock mode validated by parse_options"),
+                _ => unreachable!("invalid binary-owned search lock mode"),
             },
             writer_path: "direct VectorStore upsert under the same Tokio RwLock, with lock-wait and end-to-end durations reported separately".to_string(),
             allocation_scope: "process-global counting allocator sampled around isolated in-process API dispatch; concurrent metrics do not claim per-request allocation isolation".to_string(),
@@ -973,8 +973,7 @@ fn required_value(arguments: &mut impl Iterator<Item = String>, flag: &str) -> R
 fn print_help() {
     println!(
         "indexd real-workload benchmark\n\n\
-         Usage:\n  cargo bench -p indexd --bench indexd_real_workload -- \\\n         --profile smoke|standard|full [--output PATH] [--baseline PATH] \\\n         [--source-commit SHA] [--environment-id STABLE_HOST_ID] \\
-         [--search-lock-mode held-read-lock|namespace-snapshot]\n\n\
+         Usage:\n  cargo bench -p indexd --bench indexd_real_workload -- \\\n         --profile smoke|standard|full [--output PATH] [--baseline PATH] \\\n         [--source-commit SHA] [--environment-id STABLE_HOST_ID]\n\n\
          A failed baseline comparison exits with status 2 after writing the report."
     );
 }


### PR DESCRIPTION
## Summary

- remove the unsupported `--search-lock-mode` flag from benchmark help
- keep lock-mode identity binary-owned and fail-closed
- replace the misleading `unreachable!` explanation with the actual invariant

## Verification

- `cargo bench --locked -p indexd --bench indexd_real_workload -- --help`
- unsupported `--search-lock-mode held-read-lock` exits with status 1
- `cargo clippy --locked -p indexd --bench indexd_real_workload -- -D warnings`
- `rustfmt --check`
- `git diff --check`

Reviewed head: `08768a3a76c3523f9af42e9ce9d29ac6251d902d`
Full diff SHA-256: `4fb24330a94723cee394694666642f32896d53a5eef2d2fb670a862289205693`