### PR TITLE
docs(indexd): reconcile architecture with live code

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ SemantAH ist eine lokal laufende Wissensgraph- und Semantik-Pipeline für Obsidi
 > Eine Übersicht zu Config, API und Betrieb findest du ergänzend in:
 > - [`docs/config-reference.md`](docs/config-reference.md)
 > - [`docs/indexd-api.md`](docs/indexd-api.md)
+> - [`docs/indexd-architecture.md`](docs/indexd-architecture.md)
+> - [`docs/indexd-performance.md`](docs/indexd-performance.md)
 > - [`docs/runbook.observability.md`](docs/runbook.observability.md)
 > - [`docs/runbooks/semantics-intake.md`](docs/runbooks/semantics-intake.md)
 

--- a/crates/indexd/README.md
+++ b/crates/indexd/README.md
@@ -1,29 +1,53 @@
 # `indexd` crate
 
-`indexd` ist der HTTP-Dienst für den semantischen Index. Er kapselt den Axum-Server, einen im Speicher gehaltenen `VectorStore` und stellt CRUD-Operationen für Chunks sowie eine Suchroute bereit.
+`indexd` ist der Axum-Dienst für den semantischen Index. Die kanonische
+Ist-Architektur, Leistungsgrenzen und Nichtaussagen stehen in
+[`docs/indexd-architecture.md`](../../docs/indexd-architecture.md).
 
-## Komponenten
-- `AppState`: verwaltet den `VectorStore` (RW-Lock) und kann in Tests ersetzt werden.
-- `run`: Hilfsfunktion, die den Server standardmäßig unter `0.0.0.0:8080` startet und zusätzliche Routen injiziert. Für isolierte Tests oder abweichende Laufzeitumgebungen kann die Bind-Adresse über `INDEXD_BIND_ADDR` gesetzt werden, zum Beispiel `127.0.0.1:49152`.
-- `store`-Modul: In-Memory-Vektorablage mit Namensraum-Unterstützung und einfacher Persistenz-Erweiterbarkeit.
+## Implementierte Komponenten
+
+- `AppState`: hält einen `Tokio::RwLock<VectorStore>` und optional einen Embedder.
+- `run`: lädt optional `INDEXD_DB_PATH`, startet den Server standardmäßig auf
+  `0.0.0.0:8080` und speichert beim geordneten Shutdown atomar zurück. Die Bind-Adresse
+  kann über `INDEXD_BIND_ADDR` gesetzt werden.
+- `store`: exakte lineare Cosinus-Suche über normalisierte Vektoren, Namespace-Isolation,
+  deterministische Tie-Breaks und O(1)-Snapshots für Ranking außerhalb des Store-Locks.
+- `persist`: JSONL-Start-/Shutdown-Persistenz; kein WAL und keine kontinuierliche
+  Durability-Garantie.
 
 ## HTTP-API
-| Methode & Pfad | Beschreibung | Beispiel-Payload |
-| --- | --- | --- |
-| `POST /index/upsert` | Nimmt Chunks mit Embeddings entgegen und ersetzt vorhandene Einträge atomar. | `{ "doc_id": "note-42", "namespace": "vault", "chunks": [{ "id": "note-42#0", "text": "...", "meta": { "embedding": [0.1, 0.2], "source_path": "notes/foo.md" }}] }` |
-| `POST /index/delete` | Entfernt alle Chunks eines Dokuments aus einem Namespace. | `{ "doc_id": "note-42", "namespace": "vault" }` |
-| `POST /index/search` | Führt eine k-Nearest-Nachbarn-Suche aus und liefert Treffer mitsamt Score & Rationale zurück. Aktuell noch Stub → leeres `results`-Array. | `{ "query": "backup policy", "namespace": "vault", "k": 10 }` |
-| `GET /healthz` | Healthcheck für Liveness-Probes. | – |
 
-Antworten enthalten bei Fehlern strukturierte JSON-Bodies (`{"error": "..."}`) sowie `400 Bad Request` bei Validierungsproblemen.
+| Methode & Pfad | Verhalten |
+| --- | --- |
+| `POST /index/upsert` | Fügt Chunks ein oder ersetzt sie atomar; alle Vektoren müssen dieselbe Dimension haben. |
+| `POST /index/delete` | Entfernt alle Chunks eines Dokuments innerhalb eines Namespace. |
+| `POST /index/search` | Führt exakte Top-k-Suche aus und liefert Score sowie optional `meta.snippet`; `filters` wird derzeit nicht angewendet. |
+| `POST /embed/text` | Erzeugt über den konfigurierten Embedder ein provenancegebundenes Embedding. |
+| `GET /healthz` | Liveness-Check. |
 
-## Beispielstart
+Die vollständigen Payloads und Fehlerverträge stehen in
+[`docs/indexd-api.md`](../../docs/indexd-api.md).
+
+## Start
+
 ```bash
 cargo run -p indexd
 ```
 
-## Tests
-- `tests/healthz.rs`: prüft den Healthcheck-Endpunkt.
-- Integrationstest in `src/main.rs`: stellt sicher, dass fehlende Dimensionalität nicht zum teilweisen Upsert führt.
+Optional:
 
-Für persistente Vector-Stores oder echte Ähnlichkeitssuche kann das `store`-Modul ersetzt und `handle_search` erweitert werden.
+```bash
+export INDEXD_BIND_ADDR=127.0.0.1:49152
+export INDEXD_DB_PATH=.gewebe/indexd/store.jsonl
+cargo run -p indexd
+```
+
+## Tests und Benchmark
+
+```bash
+cargo test -p indexd --all-features --locked
+cargo bench -p indexd --bench indexd_real_workload -- --profile smoke
+```
+
+Nicht implementiert sind HNSW/Faiss/andere ANN-Indizes, Metadatenfilter, Sled/SQLite,
+Write-Ahead-Logging, Authentifizierung und Multi-Instanz-Koordination.

--- a/crates/indexd/src/main.rs
+++ b/crates/indexd/src/main.rs
@@ -1,4 +1,4 @@
-//! Minimal HTTP server stub for the semantic index daemon (indexd).
+//! HTTP server entry point for the semantic index daemon (`indexd`).
 
 use indexd::api;
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -7,6 +7,7 @@ This directory contains all the documentation for semantAH.
 -   **[Quickstart](quickstart.md):** A step-by-step guide to getting started with semantAH.
 -   **[Configuration Reference](config-reference.md):** A detailed reference for the `semantah.yml` configuration file.
 -   **[API Reference](indexd-api.md):** The HTTP API reference for the `indexd` service.
+-   **[`indexd` Architecture](indexd-architecture.md):** Canonical current-state architecture, persistence and scaling boundaries.
 -   **[Blueprint](blueprint.md):** The complete conceptual blueprint for semantAH.
 -   **[Roadmap](roadmap.md):** The development roadmap and progress.
 -   **[Feedback Loop](semantAH-feedback-loop.md):** How semantAH provides signals back to the Heimgewebe organism

--- a/docs/blueprint.md
+++ b/docs/blueprint.md
@@ -1,5 +1,10 @@
 # Vault-Gewebe: Finale Blaupause
 
+> **Status: historischer Entwurf.** HNSW-, Sled/SQLite-, HausKI-Mounting- und
+> Persistenzangaben in diesem Dokument beschreiben Zielbilder, nicht den heutigen
+> `indexd`-Code. Kanonischer Ist-Stand: [`indexd-architecture.md`](indexd-architecture.md).
+
+
 Diese Datei fasst die komplette Architektur für das semantische Vault-Gewebe zusammen. Sie kombiniert den semantischen Index, den Wissensgraphen, Obsidian-Automatismen sowie Qualitäts- und Review-Schleifen. Alle Schritte sind lokal reproduzierbar und werden in `.gewebe/` versioniert.
 
 ---

--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -1,5 +1,7 @@
 # Konfigurationsreferenz (`semantah.yml`)
 
+> **`indexd`-Laufzeit:** Der heutige Dienst liest Persistenz nicht aus `index.persist_path`, sondern ausschließlich aus `INDEXD_DB_PATH`. Die Tabellenzeile bleibt ein geplanter Konfigurationsadapter. Siehe [`indexd-architecture.md`](indexd-architecture.md).
+
 `semantah.yml` dient als zentrale Drehscheibe für die Pipeline-Konfiguration. Die Datei ist aktuell ein **Platzhalter** – die angebundenen Skripte und Dienste nutzen die Konfiguration noch nicht, sondern arbeiten mit fest kodierten Pfaden und Standardwerten.
 
 Die folgende Tabelle dokumentiert das Zielschema und den aktuellen Implementierungsstatus.
@@ -11,7 +13,7 @@ Die folgende Tabelle dokumentiert das Zielschema und den aktuellen Implementieru
 | `embedder.provider` | String | Kennung des Embedding-Providers (`ollama`, `openai`, …). | `ollama` | Stub |
 | `embedder.model` | String | Modellname/Identifier, der an den Provider übergeben wird. | `nomic-embed-text` | Stub |
 | `embedder.base_url` | URL | Optional: überschreibt die Basis-URL für lokale Provider (z. B. `http://localhost:11434`). | `http://localhost:11434` | Stub |
-| `index.top_k` | Integer | Anzahl Treffer, die bei Suchen (`/index/search`) zurückgegeben werden. | `20` | Stub (HTTP-Stub verwendet Payload `k`) |
+| `index.top_k` | Integer | Geplanter Standardwert für Suchen. Der HTTP-Endpunkt verwendet derzeit ausschließlich das Requestfeld `k`. | `20` | Konfigurationsadapter nicht implementiert |
 | `index.persist_path` | Pfad | Ablageort für den persistenten Index. | – | geplant |
 | `graph.cutoffs.min_cooccur` | Integer | Minimale Co-Vorkommnisse zweier Notizen, um eine Kante zu erzeugen. | `2` | Stub |
 | `graph.cutoffs.min_weight` | Float | Mindestgewicht für gewichtete Kanten. | `0.15` | Stub |

--- a/docs/hauski.md
+++ b/docs/hauski.md
@@ -1,5 +1,10 @@
 # HausKI-Integration
 
+> **Status: historischer Entwurf.** HNSW-, Sled/SQLite-, HausKI-Mounting- und
+> Persistenzangaben in diesem Dokument beschreiben Zielbilder, nicht den heutigen
+> `indexd`-Code. Kanonischer Ist-Stand: [`indexd-architecture.md`](indexd-architecture.md).
+
+
 HausKI bleibt das lokale Orchestrierungs-Gateway. semantAH ergänzt es als semantische Gedächtnis-Schicht. Dieser Leitfaden beschreibt, wie die neuen Komponenten (`indexd`, `embeddings`, Obsidian-Adapter) eingebunden werden und welche Policies greifen.
 
 ---

--- a/docs/indexd-api.md
+++ b/docs/indexd-api.md
@@ -41,7 +41,7 @@ Lokale Entwicklungsumgebungen laufen ohne Authentifizierung. Für produktive Set
 - **Antwort:** `{ "status": "accepted" }`
 
 ### `POST /index/search`
-- **Zweck:** Führt eine vektorbasierte Suche aus.
+- **Zweck:** Führt eine exakte lineare Vektorsuche innerhalb eines Namespace aus.
 - **Body:**
   ```json
   {
@@ -65,7 +65,7 @@ Lokale Entwicklungsumgebungen laufen ohne Authentifizierung. Für produktive Set
         "chunk_id": "note-42#0",
         "score": 0.87,
         "snippet": "...",
-        "rationale": ["Tag match: policy", "Vector cosine: 0.87"]
+        "rationale": []
       }
     ]
   }
@@ -82,7 +82,7 @@ Lokale Entwicklungsumgebungen laufen ohne Authentifizierung. Für produktive Set
   Server `INDEXD_EMBEDDER_PROVIDER=ollama` (plus optionale Parameter) gesetzt,
   wird – falls kein Embedding im Request vorliegt – der Query-Text über den
   konfigurierten Provider eingebettet.
-  Aktuell liefert der Stub eine leere Trefferliste; das Schema ist dennoch stabil und kann für Clients genutzt werden.
+  Die Suche scannt den gewählten Namespace exakt und sortiert nach Cosinus-Score. `snippet` stammt aus `meta.snippet`; `rationale` ist derzeit leer. Das optionale `filters`-Feld wird akzeptiert, aber noch nicht ausgewertet.
 
 ### `GET /healthz`
 - **Zweck:** Liveness-Check; antwortet mit `200 OK` und Body `"ok"`.
@@ -127,12 +127,12 @@ Lokale Entwicklungsumgebungen laufen ohne Authentifizierung. Für produktive Set
 
 ## Antwortschema & Fehlercodes
 - Erfolgreiche Antworten sind JSON (`application/json`).
-+- **400 Bad Request**: Clientseitige Probleme (z. B. falsches `embedding`-Format,
-+  Dimensionsmismatch, invalides JSON) – Response: `{ "error": "…" }`.
-+- **503 Service Unavailable**: Serverseitige Einbettung fehlgeschlagen
-+  (z. B. Embedder/Provider nicht erreichbar oder liefert keine Vektoren).
-+  Clients sollten verzögert **retry** ausführen. Response: `{ "error": "…" }`.
- - Weitere HTTP-Codes (z. B. `500`) sind für zukünftige Persistenzfehler reserviert.
+- **400 Bad Request**: Clientseitige Probleme (z. B. falsches `embedding`-Format,
+  Dimensionsmismatch, invalides JSON) – Response: `{ "error": "…" }`.
+- **503 Service Unavailable**: Serverseitige Einbettung fehlgeschlagen
+  (z. B. Embedder/Provider nicht erreichbar oder liefert keine Vektoren).
+  Clients sollten verzögert **retry** ausführen. Response: `{ "error": "…" }`.
+- Weitere HTTP-Codes (z. B. `500`) bleiben für interne Fehler reserviert. Persistenzfehler können beim Start oder geordneten Shutdown auftreten und liegen nicht im Requestpfad.
 
 ## Beispiele mit `curl`
 ```bash

--- a/docs/indexd-architecture.md
+++ b/docs/indexd-architecture.md
@@ -1,0 +1,125 @@
+# `indexd`: Architektur und belegter Implementierungsstand
+
+Dieses Dokument ist die kanonische Ist-Beschreibung des Rust-Dienstes `indexd`.
+Historische Entwürfe und Roadmaps dürfen hiervon abweichen, müssen aber ausdrücklich als
+Plan oder Konzept gekennzeichnet sein. Bei Widersprüchen gelten Code, Tests und
+commitgebundene Benchmarkberichte vor beschreibendem Text.
+
+## Kurzfassung
+
+`indexd` ist derzeit ein einzelner Axum-Dienst mit einem pro Prozess gehaltenen
+`VectorStore`. Er bietet Upsert, dokumentweises Löschen, exakte Vektorsuche und optional
+serverseitige Texteinbettung. Es gibt **keinen HNSW-, Faiss- oder anderen ANN-Index**.
+
+Die Suche normalisiert Vektoren und führt einen exakten linearen Scan innerhalb genau
+eines Namespace aus. Da gespeicherte und angefragte Vektoren auf Einheitslänge
+normalisiert werden, entspricht das verwendete Skalarprodukt der Cosinus-Ähnlichkeit.
+
+## Laufzeitaufbau
+
+- `AppState` hält `Arc<Tokio::RwLock<VectorStore>>` und optional einen `Embedder`.
+- `VectorStore` erzwingt eine gemeinsame Vektordimensionalität über alle Namespaces.
+- Jeder Namespace enthält eine zusammenhängende Liste `Arc<StoredItem>` für den linearen
+  Scan und eine Key→Index-Abbildung für Ersetzen und Metadatenzugriff.
+- Upsert und Delete laufen unter dem Write-Lock des Stores.
+- Die HTTP-Suche hält den Read-Lock nur für die O(1)-Aufnahme eines
+  `Arc<NamespaceItems>`-Snapshots und das Lesen der Dimension.
+- Normalisierung, Ranking und Snippet-Erzeugung laufen danach außerhalb des gemeinsamen
+  Store-Locks in `spawn_blocking`.
+
+Ein in-flight Request sieht dadurch eine konsistente Namespace-Version. Überlappt ein
+Writer mit einem gehaltenen Snapshot, kopiert `Arc::make_mut` die Namespace-Liste und den
+Key-Index flach. Unveränderte Keys, Embeddings und Metadaten bleiben referenzgeteilt.
+
+## Suchvertrag
+
+1. `k` muss größer als null sein.
+2. Das Query-Embedding wird in dieser Reihenfolge ermittelt:
+   `query.meta.embedding`, Top-Level `embedding`, Legacy-Top-Level `meta.embedding`,
+   optional konfigurierter Server-Embedder.
+3. Leere oder dimensionsfalsche Vektoren werden abgewiesen.
+4. Der Query-Vektor wird normalisiert.
+5. Alle Einträge des gewählten Namespace werden exakt gescannt.
+6. Ein begrenzter Heap hält die besten `k` Treffer; Score-Gleichstände werden
+   deterministisch nach Dokument- und Chunk-ID aufgelöst.
+7. `snippet` stammt aus `meta.snippet`; `rationale` ist derzeit leer.
+
+Das Feld `filters` ist Teil des akzeptierten Requestschemas, wird aber im aktuellen
+Store noch **nicht ausgewertet**. Clients dürfen daraus keine Filtergarantie ableiten.
+
+Komplexität der exakten Suche: O(n × d) für `n` Namespace-Einträge und `d`
+Vektordimensionen, zuzüglich O(log k) pro Heap-Aktualisierung. Snapshotaufnahme selbst
+ist O(1).
+
+## Persistenzvertrag
+
+Wenn `INDEXD_DB_PATH` gesetzt ist:
+
+- beim Start wird die JSONL-Datei in einem Blocking-Task vollständig gelesen;
+- Zeilen mit abweichender Dimension werden protokolliert und übersprungen;
+- gültige Einträge werden über den normalen Upsert-Pfad normalisiert und aufgebaut;
+- beim geordneten Shutdown wird der gesamte Store in eine temporäre Datei geschrieben
+  und per Rename atomar ersetzt.
+
+Jede Zeile enthält `namespace`, `doc_id`, `chunk_id`, `embedding` und `meta`.
+
+Diese Persistenz ist ein Start-/Shutdown-Snapshot. Sie ist **kein** Write-Ahead-Log,
+keine kontinuierliche Durability-Garantie, kein Multi-Prozess-Store und keine
+transaktionale Datenbank. Sled, SQLite und binäre ANN-Snapshots sind nicht implementiert.
+
+## Belegte Leistungsgrenze
+
+Der Benchmark `indexd_real_workload` ruft den produktiven Axum-Handler in-process auf.
+Der kontrollierte A/B-Bericht für PR #261 ist an den geprüften Head
+`2b42a5339bd90cb8ffe1519967fd51113be70a1a` gebunden und hat SHA-256
+`041ddef812a34db595f7a129665ffd83029a0c50eb5d620f0e75d9bc2e75f1e9`.
+
+Im Standardprofil lagen die sequenziellen p95-Werte bei:
+
+| Namespacegröße × Dimension | p95 | parallele Suche p95 | Writer-Lock-Wartezeit p95 |
+| --- | ---: | ---: | ---: |
+| 5.000 × 384 | 0,616 ms | 0,778 ms | 0,000110 ms |
+| 10.000 × 768 | 2,987 ms | 2,901 ms | 0,000050 ms |
+| 10.000 × 1.536 | 4,842 ms | 7,157 ms | 0,000050 ms |
+
+Dies sind synthetische, hostgebundene In-process-Daten. Sie belegen weder
+Produktionskapazität noch Netzwerk-, Reverse-Proxy- oder Multi-Instanz-Latenz.
+Weitere Details und Reproduktionsregeln stehen in
+[`indexd-performance.md`](indexd-performance.md).
+
+## Statusmatrix
+
+| Fähigkeit | Status |
+| --- | --- |
+| Axum-API für Upsert, Delete, Search und Embed Text | implementiert |
+| exakte Cosinus-Suche innerhalb eines Namespace | implementiert |
+| deterministische Score-Tie-Breaks | implementiert |
+| O(1)-Namespace-Snapshot vor Ranking | implementiert |
+| JSONL-Laden beim Start und atomisches Speichern beim Shutdown | implementiert |
+| serverseitiges Query-Embedding | optional implementiert |
+| Metadatenfilter in der Suche | nicht implementiert; Feld wird ignoriert |
+| HNSW/Faiss/anderer ANN-Index | nicht implementiert |
+| Sled/SQLite als Metadaten- oder Vektorstore | nicht implementiert |
+| Write-Ahead-Log oder kontinuierliche Persistenz | nicht implementiert |
+| Authentifizierung, Rate-Limiting, Multi-Instanz-Koordination | nicht implementiert |
+
+## ANN-Entscheidungsgrenze
+
+ANN ist eine spätere, messpflichtige Entscheidung und keine bereits gewählte
+Architektur. Eine Einführung benötigt mindestens:
+
+- einen repräsentativen Korpus und exakte Suche als Ground Truth;
+- festgelegte Recall@k- und Latenzbudgets;
+- Speicher-, Build-, Update-, Delete- und Wiederanlaufmessungen;
+- einen persistenzgebundenen Format- und Migrationsvertrag;
+- deterministischen Fallback auf exakte Suche unterhalb einer belegten Schwelle;
+- Negativtests für beschädigte Indizes und dimensions-/modellfremde Daten.
+
+Bis diese Verträge erfüllt und eine Aktivierungsschwelle belegt sind, bleibt exakte
+Suche der kanonische Pfad.
+
+## Nichtaussagen
+
+Dieses Dokument belegt keine Produktionsreife, keine ANN-Notwendigkeit, keine
+Filtersemantik, keine Crash-Durability zwischen Upserts und Shutdown, keine
+Lock-Freiheit und keine über den getesteten Einzelprozess hinausgehende Konsistenz.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -4,12 +4,18 @@ Quelle: /home/alex/vault-gewebe/coding/semantAH/semantAH brainstorm.md
 
 # semantAH Roadmap
 
-Dieses Dokument überträgt die Ideen aus der Brainstorming-Notiz in umsetzbare Meilensteine.
+Dieses Dokument überträgt Ideen aus einer historischen Brainstorming-Notiz in mögliche Meilensteine. Es ist kein Ist-Nachweis. Der aktuelle `indexd`-Stand ist in [`indexd-architecture.md`](indexd-architecture.md) dokumentiert.
 
-## Milestone 1 – Grundgerüst
-- Rust-Workspace mit `embeddings`-Crate (Ollama-Backend) und `indexd`-Crate (Axum-HTTP, HNSW-Wrapper).
-- Persistenz-Pfade `.local/state/hauski/index/obsidian` vorbereiten.
-- Feature-Flags: `safe_mode`, `limits.latency.index_topk20_ms` an HNSW koppeln.
+## Aktueller Abgleich
+
+- Rust-Workspace, Axum-Routen, exakte Suche und JSONL-Start-/Shutdown-Persistenz sind implementiert.
+- HNSW, ANN-Aktivierung, Metadatenfilter, `safe_mode`-Kopplung und ein `index_topk20_ms`-Runtime-Gate sind nicht implementiert.
+- ANN bleibt von einer separaten evidenzbasierten Aktivierungsschwelle abhängig.
+
+## Historischer Milestone 1 – Grundgerüst
+- Rust-Workspace mit `embeddings`-Crate und `indexd`-Crate. Der heutige Store ist exakt-linear; der damals vorgesehene HNSW-Wrapper wurde nicht umgesetzt.
+- Persistenz ist heute optional über `INDEXD_DB_PATH` als JSONL-Start-/Shutdown-Snapshot umgesetzt; der damalige HausKI-Pfad ist nicht kanonisch.
+- Historische Planung: `safe_mode` und `limits.latency.index_topk20_ms` an einen möglichen ANN-Pfad koppeln; nicht implementiert.
 - Erste HTTP-Routen:
   - `POST /index/upsert`
   - `POST /index/delete`

--- a/docs/semantAH brainstorm.md
+++ b/docs/semantAH brainstorm.md
@@ -1,5 +1,10 @@
 mega–ja. wir bauen das selbst – aber so, dass es perfekt in dein repo passt. hier ist der konkrete blueprint für “semantische suche / vektor-index” als hauski-dienst + dünnes obsidian-plugin-frontend.
 
+> **Status: historischer Entwurf.** HNSW-, Sled/SQLite-, HausKI-Mounting- und
+> Persistenzangaben in diesem Dokument beschreiben Zielbilder, nicht den heutigen
+> `indexd`-Code. Kanonischer Ist-Stand: [`indexd-architecture.md`](indexd-architecture.md).
+
+
 (ich beziehe mich dabei auf deine repo-struktur, configs und bereits vorhandene core-server-grundlagen wie /health, /metrics, CORS, „safe_mode“, egress-guard usw. – die sehen schon sehr solide aus.  ￼)
 
 zielbild (kompakt)

--- a/docs/semantAH/comprehensive-optimization-strategy.md
+++ b/docs/semantAH/comprehensive-optimization-strategy.md
@@ -2,7 +2,7 @@
 
 > **Historischer Konzeptstand:** Die folgenden Organismus- und Rollenbilder sind nicht normativ.
 > Aktuelle Systemzwecke und Beziehungen werden im [Systemkatalog](https://github.com/heimgewebe/systemkatalog) geführt; technische
-> Aussagen sind gegen den heutigen Repositoryzustand zu prüfen.
+> Aussagen sind gegen den heutigen Repositoryzustand zu prüfen. Die kanonische Ist-Beschreibung von `indexd` steht in [`../indexd-architecture.md`](../indexd-architecture.md).
 
 Dieses Dokument vereint die technische Architektur-Analyse mit den semantischen Optimierungsstrategien, um *semantAH* zu einem robusten, leistungsfähigen und „verständigen“ Wissens-Organ im Heimgewebe-Organismus zu entwickeln.
 
@@ -49,7 +49,7 @@ Alle Schema-Definitionen liegen kanonisch im `metarepo/contracts/`.
 ### Rust-Teil
 
 *   **Crate `embeddings`:** Definiert das `Embedder`-Trait mit asynchroner `embed`-Methode. Die vorhandene Ollama-Implementation ist modular und testgetrieben, validiert Dimensions-Mismatchs und verarbeitet Batches. Einschränkungen sind die Beschränkung auf Ollama und rudimentäre Fehlerbehandlung.
-*   **Crate `indexd`:** Implementiert einen Axum-HTTP-Service (Upsert, Delete, Search, Embed Text). Die API validiert JSON-Payloads und nutzt einen in-memory `VectorStore`. Die Suche erfolgt linear über normalisierte Vektoren (Cosinus-Ähnlichkeit). Es fehlen Persistenz und Approximate-Nearest-Neighbour-Indizes (ANN).
+*   **Crate `indexd`:** Implementiert einen Axum-HTTP-Service (Upsert, Delete, Search, Embed Text). Die API validiert JSON-Payloads und nutzt einen In-memory-`VectorStore`. Die Suche erfolgt exakt und linear über normalisierte Vektoren. JSONL-Laden beim Start und atomisches Speichern beim geordneten Shutdown sind optional über `INDEXD_DB_PATH` implementiert. ANN, kontinuierliche Durability und Metadatenfilter sind nicht implementiert.
 
 ### Python-Teil
 
@@ -65,8 +65,8 @@ Alle Schema-Definitionen liegen kanonisch im `metarepo/contracts/`.
 
 ### 3.2 Leistungsfähiger Vektorindex
 
-*   **ANN-Algorithmen:** Integration von HNSWlib oder Faiss (via `hnsw_rs` o.ä.) für logarithmische Skalierbarkeit statt linearer Suche.
-*   **Persistenz:** Speichern des Index als JSONL oder Binärformat (z. B. `.gewebe/indexd/store.jsonl`) mit asynchronem Laden/Speichern und optionalem Write-Ahead-Log.
+*   **ANN-Algorithmen (bedingt):** HNSW, Faiss oder ein anderer ANN-Pfad darf erst nach einem recall-, latenz-, speicher- und rebuildgebundenen Vergleich gegen die exakte Ground Truth aktiviert werden. Die Aktivierungsschwelle ist noch nicht definiert.
+*   **Persistenz:** JSONL-Start-/Shutdown-Persistenz ist implementiert. Offen sind ein belastbarer Crash-Durability-Vertrag, optionales Write-Ahead-Logging, inkrementelle Sicherung und ein migrationsfähiges Format für einen möglichen ANN-Index.
 *   **Parallelisierung:** Sharding nach Namespaces oder Hash-Bereichen für Multi-Core-Nutzung.
 *   **Trennung von Logik & Index:** Filter- und Ranking-Logiken (Zeit-Boosts, Tags) sollten strukturell vom reinen Index getrennt sein.
 

--- a/tests/test_indexd_documentation_truth.py
+++ b/tests/test_indexd_documentation_truth.py
@@ -1,0 +1,65 @@
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def read(relative: str) -> str:
+    return (ROOT / relative).read_text(encoding="utf-8")
+
+
+def test_canonical_indexd_architecture_is_linked() -> None:
+    architecture = read("docs/indexd-architecture.md")
+    assert "keinen HNSW" in architecture
+    assert "filters` ist Teil" in architecture
+    assert "INDEXD_DB_PATH" in architecture
+    assert "O(n × d)" in architecture
+    assert "indexd-architecture.md" in read("docs/README.md")
+    assert "indexd-architecture.md" in read("README.md")
+    assert "indexd-architecture.md" in read("crates/indexd/README.md")
+
+
+def test_current_indexd_docs_do_not_claim_stub_or_ann_store() -> None:
+    crate_readme = read("crates/indexd/README.md")
+    api = read("docs/indexd-api.md")
+    assert "Aktuell noch Stub" not in crate_readme
+    assert "Aktuell liefert der Stub" not in api
+    assert '"rationale": ["Tag match' not in api
+    assert "filters`-Feld wird akzeptiert, aber noch nicht ausgewertet" in api
+    assert "HNSW/Faiss/andere ANN-Indizes" in crate_readme
+
+
+def test_historical_hnsw_documents_are_marked_non_authoritative() -> None:
+    for relative in (
+        "docs/hauski.md",
+        "docs/blueprint.md",
+        "docs/semantAH brainstorm.md",
+    ):
+        prefix = read(relative)[:800]
+        assert "Status: historischer Entwurf" in prefix, relative
+        assert "indexd-architecture.md" in prefix, relative
+
+
+def test_strategy_and_roadmap_match_live_persistence_boundary() -> None:
+    strategy = read("docs/semantAH/comprehensive-optimization-strategy.md")
+    roadmap = read("docs/roadmap.md")
+    config = read("docs/config-reference.md")
+    assert "Es fehlen Persistenz" not in strategy
+    assert "JSONL-Laden beim Start" in strategy
+    assert "damals vorgesehene HNSW-Wrapper wurde nicht umgesetzt" in roadmap
+    assert "ausschließlich aus `INDEXD_DB_PATH`" in config
+    assert "HTTP-Stub" not in config
+    assert "server stub" not in read("crates/indexd/src/main.rs")
+
+
+def test_documented_indexd_links_resolve() -> None:
+    expected = ROOT / "docs/indexd-architecture.md"
+    assert expected.is_file()
+    for relative in (
+        "README.md",
+        "docs/README.md",
+        "docs/hauski.md",
+        "docs/blueprint.md",
+        "docs/semantAH brainstorm.md",
+        "crates/indexd/README.md",
+    ):
+        assert "indexd-architecture.md" in read(relative), relative


### PR DESCRIPTION
## Summary

- establish `docs/indexd-architecture.md` as the canonical current-state description
- document exact linear cosine search, O(1) namespace snapshots, shallow copy-on-write and JSONL start/shutdown persistence
- state explicitly that filters, HNSW/Faiss/ANN, Sled/SQLite, WAL, authentication and multi-instance coordination are not implemented
- correct the `indexd` crate README and HTTP API reference, including empty rationale and ignored filters
- mark historical HNSW/HausKI blueprints as non-authoritative instead of deleting them
- add a regression guard preventing current docs from reverting to stub or implemented-ANN claims

## Evidence

Reviewed head: `32a6c5327393f540d68fd3c19fb91f4352c9bab2`
Base: `13f65d9f43bbc711ac5a74e90ce76155613d3c57`
Full diff SHA-256: `02eacf928cfb2643b647457abe4d41eda3fe3cdb5f9c2bae195adb74d593626e`
Source live-register event: `615`

## Verification

- documentation truth guard: 5 passed
- Python unit gate: 106 passed, 2 optional-dependency skips, 1 integration deselected
- `cargo test --workspace --all-features --locked`
- `cargo clippy --workspace --all-features --locked -- -D warnings`
- Ruff check and format check
- changed Rust file rustfmt check
- `git diff --check`

## Integration-test note

A full bare `python3 -m pytest -q` run reached 106 passes and failed only in `tests/test_push_index_e2e.py` because the isolated systemd test task did not expose `cargo` through `PATH`. The same repository Rust tests pass through the absolute Cargo path. Attempts to alter the task environment were blocked before process start, so that environment-specific E2E invocation is not claimed as passed.

## Nonclaims

This PR does not implement ANN, filters, stronger durability, authentication or production capacity. It reconciles documentation with the already tested runtime.