### PR TITLE
ci: require portable push-index E2E

### DIFF
--- a/.github/workflows/push-index-e2e.yml
+++ b/.github/workflows/push-index-e2e.yml
@@ -1,0 +1,26 @@
+name: Push-index E2E portability
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  push-index-e2e:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v4
+        with: { python-version: "3.11" }
+      - uses: dtolnay/rust-toolchain@stable
+      - name: Install locked test environment
+        run: uv sync --frozen --extra test
+      - name: Verify push-index portability with port 8080 occupied
+        env:
+          INDEXD_E2E_HEALTHZ_DEADLINE: "120"
+        run: uv run --frozen --extra test pytest -q tests/test_push_index_e2e.py

--- a/.github/workflows/wgx-reusable.yml
+++ b/.github/workflows/wgx-reusable.yml
@@ -16,22 +16,6 @@ permissions:
   contents: read
 
 jobs:
-  push-index-e2e:
-    name: Push-index E2E portability
-    runs-on: ubuntu-latest
-    timeout-minutes: 15
-    steps:
-      - uses: actions/checkout@v4
-      - uses: astral-sh/setup-uv@v4
-        with: { python-version: "3.11" }
-      - uses: dtolnay/rust-toolchain@stable
-      - name: Install locked test environment
-        run: uv sync --frozen --extra test
-      - name: Verify push-index portability with port 8080 occupied
-        env:
-          INDEXD_E2E_HEALTHZ_DEADLINE: "120"
-        run: uv run --frozen --extra test pytest -q tests/test_push_index_e2e.py
-
   wgx:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/wgx-reusable.yml
+++ b/.github/workflows/wgx-reusable.yml
@@ -16,6 +16,22 @@ permissions:
   contents: read
 
 jobs:
+  push-index-e2e:
+    name: Push-index E2E portability
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v4
+        with: { python-version: "3.11" }
+      - uses: dtolnay/rust-toolchain@stable
+      - name: Install locked test environment
+        run: uv sync --frozen --extra test
+      - name: Verify push-index portability with port 8080 occupied
+        env:
+          INDEXD_E2E_HEALTHZ_DEADLINE: "120"
+        run: uv run --frozen --extra test pytest -q tests/test_push_index_e2e.py
+
   wgx:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Bureau-Task: SEMANTAH-E2E-PORTABILITY-V1-T001

## Ziel

Schließt den verbliebenen CI-Regressionsblocker der bereits über PR #258 implementierten Push-index-Portabilität. Ein eigenständiger Pflichtworkflow führt den portablen E2E-Test bei jedem Pull Request und jedem Push auf `main` aus.

## Änderung

- ergänzt `.github/workflows/push-index-e2e.yml`
- installiert die durch `uv.lock` gebundene Testumgebung
- stellt eine Rust-Toolchain für `indexd` bereit
- führt gezielt `tests/test_push_index_e2e.py` aus
- hält Port 8080 belegt, nutzt einen freien Loopback-Port, wartet auf `/healthz` und prüft die Prozessbereinigung
- lässt den bestehenden wiederverwendbaren WGX-Workflow unverändert

## Prüfungen auf aktuellem Head

- Workflow-Vertrag per YAML-Readback: PASS
- gezielter Portabilitäts-E2E: 1 bestanden
- vollständige Python-Suite: 114 bestanden
- `git diff --check`: PASS
- WGX `smoke`/`guard` bleiben unverändert; lokal fehlt `yq`, GitHub installiert `mikefarah/yq@v4`

## Review

Methodisch getrennter, nicht unabhängiger Self-Review des vollständigen aktuellen Diffs: PASS. Der erste Ansatz im wiederverwendbaren Workflow löste bei Aufrufern ungültige Workflowläufe aus und wurde im selben Zyklus vollständig zurückgenommen. Der eigenständige Workflow vermeidet diese Kopplung. Keine offenen P1/P2 und kein mergeblockierender P3.

## Diff-Bindung

- Base: `871d84ffffe0a2bc9f429a395fe7d2c79641083d`
- Head: `b766ccdf67e9dca37e08b79980f12120a480473e`
- Diff-SHA-256: `34608e31c9f851a7a8b340a7f0de136215cd1be6243573e0ac85dc70f62031ed`
- vollständiger UTF-8-Diff: `/home/alex/.local/share/grabowski/artifacts/semantah-e2e-portability-v1-t001-pr-diff.txt`
