### PR TITLE
chore(deps): update axum to 0.8

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -100,13 +100,13 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "axum"
-version = "0.7.9"
+version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edca88bc138befd0323b20752846e6587272d3b03b0343c8ea28a6f819e6e71f"
+checksum = "31b698c5f9a010f6573133b09e0de5408834d0c82f8d7475a89fc1867a71cd90"
 dependencies = [
- "async-trait",
  "axum-core",
  "bytes",
+ "form_urlencoded",
  "futures-util",
  "http",
  "http-body",
@@ -119,8 +119,7 @@ dependencies = [
  "mime",
  "percent-encoding",
  "pin-project-lite",
- "rustversion",
- "serde",
+ "serde_core",
  "serde_json",
  "serde_path_to_error",
  "serde_urlencoded",
@@ -134,19 +133,17 @@ dependencies = [
 
 [[package]]
 name = "axum-core"
-version = "0.4.5"
+version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09f2bd6146b97ae3359fa0cc6d6b376d9539582c7b4220f041a33ec24c226199"
+checksum = "08c78f31d7b1291f7ee735c1c6780ccde7785daae9a9206026862dab7d8792d1"
 dependencies = [
- "async-trait",
  "bytes",
- "futures-util",
+ "futures-core",
  "http",
  "http-body",
  "http-body-util",
  "mime",
  "pin-project-lite",
- "rustversion",
  "sync_wrapper",
  "tower-layer",
  "tower-service",
@@ -998,9 +995,9 @@ dependencies = [
 
 [[package]]
 name = "matchit"
-version = "0.7.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
+checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
 name = "memchr"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ readme = "README.md"
 [workspace.dependencies]
 anyhow = "1"
 async-trait = "0.1"
-axum = { version = "0.7", features = ["json"] }
+axum = { version = "0.8", features = ["json"] }
 futures = "0.3"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/crates/embeddings/Cargo.toml
+++ b/crates/embeddings/Cargo.toml
@@ -15,7 +15,7 @@ tracing.workspace = true
 tokio = { workspace = true, features = ["sync"] }
 
 [dev-dependencies]
-axum = "0.7"
+axum = "0.8"
 anyhow = "1"
 hyper = { version = "1", features = ["server"] }
 serde_json = "1"

--- a/crates/indexd/src/api.rs
+++ b/crates/indexd/src/api.rs
@@ -16,7 +16,6 @@ use crate::AppState;
 /// return JSON format `{"error": "..."}` instead of plain text.
 pub struct ApiJson<T>(pub T);
 
-#[axum::async_trait]
 impl<S, T> axum::extract::FromRequest<S> for ApiJson<T>
 where
     T: serde::de::DeserializeOwned,


### PR DESCRIPTION
Bureau task: OPERATOR-INTEGRATION-LOOP-V1-T022
Run: BUR-RUN-20260803T003645Z-a5228a46f8

Replaces the closed, unmerged PR #267 on current main. Updates axum to 0.8.9 and removes the obsolete axum::async_trait annotation from ApiJson's FromRequest implementation.

Exact-head local evidence for e378b9b:
- cargo check --workspace --all-targets: PASS
- push-index-e2e portability test: PASS (1 passed)
- cargo tree -i axum --locked: axum v0.8.9 for indexd and embeddings dev-dependency
- git diff --check: PASS

Note: cargo fmt --all -- --check still reports a pre-existing formatting difference in crates/embeddings/tests/ollama_mock.rs, outside this diff. No unrelated formatting mutation was included.