### PR TITLE
docs: bind implementation summary to issue 207

### DIFF
--- a/IMPLEMENTATION_SUMMARY.md
+++ b/IMPLEMENTATION_SUMMARY.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-This PR implements the stable embedding service and knowledge observatory tracking as specified in issue #[number]. The implementation follows the principle of **contract-driven minimality**: observing and counting, not interpreting.
+This PR implements the stable embedding service and knowledge observatory tracking as specified in issue #207. The implementation follows the principle of **contract-driven minimality**: observing and counting, not interpreting.
 
 ## What Was Implemented
 


### PR DESCRIPTION
## Summary
- replace the unresolved `issue #[number]` placeholder with verified issue `#207`
- preserve the original implementation-summary wording otherwise unchanged

## Provenance
- original summary commit: `b273bd05ae211689c129b77fa53899acefe60dc4`
- original implementation PR: #208
- PR #208 explicitly contains `Fixes heimgewebe/semantAH#207` and GitHub reports issue #207 in `closingIssuesReferences`
- Bureau scout: `BUR-RUN-20260823T210241Z-f66acdeff9`
- follow-up candidate: `candidate-61e72edf54a2f18054ef9f07` / event `10724`

## Verification
- `git diff --check`
- unresolved placeholder absent
- `issue #207` present exactly at the intended sentence
- no code/runtime changes