### PR TITLE
fix(test): self-provision coverage dependencies

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -65,6 +65,7 @@ test-integration:
 #   reports/coverage-unit.xml (Cobertura/XML)
 #   reports/.coverage         (sqlite)
 coverage: | coverage-clean
+	uv sync --extra test
 	mkdir -p reports
 	uv run pytest $(PYTEST_ADDOPTS) -m "not integration" \
 	  --junitxml=reports/unit-junit.xml \


### PR DESCRIPTION
## Summary
- make `coverage` provision the existing `test` optional dependencies before invoking pytest
- keep the change limited to the Makefile coverage contract

## Verification
- Fresh baseline: `uv sync` followed by `make coverage` failed because `--cov` was unavailable
- After change: `make coverage` succeeds with 113 passed / 1 deselected and writes the coverage XML
- `make lint` succeeds (`ruff check`, `ruff format --check`)
- `make test` succeeds with 113 passed / 1 deselected

Bureau task: `OPERATOR-INTEGRATION-LOOP-V1-FB-SEMANTAH-COVERAGE-SYNC-20260825`
Bureau run: `BUR-RUN-20260826T141804Z-ff24dc24f0`